### PR TITLE
Create mate-system-monitor.appdata.xml

### DIFF
--- a/mate-system-monitor.appdata.xml
+++ b/mate-system-monitor.appdata.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 MATE team <mate-dev@ml.mate-desktop.org> -->
+<component type="desktop">
+ <id>mate-system-monitor.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-2.0+</project_license>
+ <name>Mate System Monitor</name>
+ <summary>A Process and resource monitor for MATE Desktop</summary>
+ <description>
+  <p>
+   Mate System Monitor allows to graphically view and manipulate the running
+   processes on your system. It also provides an overview of available resources,
+   such as CPU and memory.
+  </p>
+  <p>
+   Mate System Monitor is a fork of GNOME System Monitor and part of the MATE
+   Desktop Environment. If you would like to know more about MATE and System Monitor,
+   please visit the project's home page.
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/mate-system-monitor/screens/mate-system-monitor_01.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/mate-system-monitor/screens/mate-system-monitor_02.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/mate-system-monitor/screens/mate-system-monitor_03.png
+   </image>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">http://www.mate-desktop.org</url>
+ <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
+ <project_group>MATE</project_group>
+</component>


### PR DESCRIPTION
An appdata file for inclusion in the upcoming software centers as per the new freedesktop.org specs.

It should be placed in /usr/share/appdata/ similar to the way .desktop files are placed in /usr/share/applications/, e.g. if you have a "$(datadir)/applications" definition in your makefiles, you need to add a "$(datadir)/appdata" as well.

Please, skim through the file in case I made a mistake and please, include it in the 1.8 branch as well.

Thanks!
