### PR TITLE
process table: force icon size on loading

### DIFF
--- a/src/prettytable.cpp
+++ b/src/prettytable.cpp
@@ -116,7 +116,7 @@ PrettyTable::unregister_application(pid_t pid)
 Glib::RefPtr<Gdk::Pixbuf>
 PrettyTable::get_icon_from_theme(const ProcInfo &info)
 {
-    return this->theme->load_icon(info.name, APP_ICON_SIZE, Gtk::ICON_LOOKUP_USE_BUILTIN);
+    return this->theme->load_icon(info.name, APP_ICON_SIZE, Gtk::ICON_LOOKUP_USE_BUILTIN | Gtk::ICON_LOOKUP_FORCE_SIZE);
 }
 
 
@@ -149,7 +149,7 @@ PrettyTable::get_icon_from_default(const ProcInfo &info)
         IconCache::iterator it(this->defaults.find(name));
 
         if (it == this->defaults.end()) {
-            pix = this->theme->load_icon(name, APP_ICON_SIZE, Gtk::ICON_LOOKUP_USE_BUILTIN);
+            pix = this->theme->load_icon(name, APP_ICON_SIZE, Gtk::ICON_LOOKUP_USE_BUILTIN | Gtk::ICON_LOOKUP_FORCE_SIZE);
             if (pix)
                 this->defaults[name] = pix;
             } else
@@ -179,7 +179,7 @@ PrettyTable::get_icon_from_wnck(const ProcInfo &info)
 Glib::RefPtr<Gdk::Pixbuf>
 PrettyTable::get_icon_from_name(const ProcInfo &info)
 {
-    return this->theme->load_icon(info.name, APP_ICON_SIZE, Gtk::ICON_LOOKUP_USE_BUILTIN);
+    return this->theme->load_icon(info.name, APP_ICON_SIZE, Gtk::ICON_LOOKUP_USE_BUILTIN | Gtk::ICON_LOOKUP_FORCE_SIZE);
 }
 
 


### PR DESCRIPTION
fixes the huge icon of ```mate-sensors-applet``` process in LMDE 2

adapted from
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=5480731230f9c6849fbf0aea1288b18bc9e62480

@clefebvre @raveit65 please test for any possible regressions

Latest comments at https://bugzilla.gnome.org/738467 say something about that bug striking again... but upstream code is a bit different. I can test it with ```mate-sensors-applet``` running only with GTK+ 3.14, so I'm curious how things are with more recent versions...