### PR TITLE
delay saving columns width to GSettings by 250 ms

### DIFF
--- a/src/proctable.cpp
+++ b/src/proctable.cpp
@@ -183,27 +183,42 @@ proctable_get_columns_order(GtkTreeView *treeview)
     return order;
 }
 
-void
-cb_proctable_column_resized(GtkWidget *widget)
+static guint timeout_id = 0;
+static GtkTreeViewColumn *current_column;
+
+static gboolean
+save_column_width (gpointer data)
 {
-    GtkTreeViewColumn *column = GTK_TREE_VIEW_COLUMN(widget);
     gint width;
     gchar *key;
     int id;
     GSettings *settings;
-    gint saved_width;
 
-    settings = g_settings_get_child (ProcData::get_instance()->settings, "proctree");
-    id = gtk_tree_view_column_get_sort_column_id (column);
-    width = gtk_tree_view_column_get_width (column);
+    settings = g_settings_get_child (G_SETTINGS (data), "proctree");
+    id = gtk_tree_view_column_get_sort_column_id (current_column);
+    width = gtk_tree_view_column_get_width (current_column);
+
     key = g_strdup_printf ("col-%d-width", id);
-
-    g_settings_get (settings, key, "i", &saved_width);
-    if (saved_width!=width)
-    {
-        g_settings_set_int(settings, key, width);
-    }
+    g_settings_set_int(settings, key, width);
     g_free (key);
+
+    if (timeout_id) {
+        g_source_remove (timeout_id);
+        timeout_id = 0;
+    }
+
+    return FALSE;
+}
+
+void
+cb_proctable_column_resized(GtkWidget *widget, GParamSpec *pspec, gpointer data)
+{
+    current_column = GTK_TREE_VIEW_COLUMN(widget);
+
+    if (timeout_id)
+        g_source_remove (timeout_id);
+
+    timeout_id = g_timeout_add (250, save_column_width, data);
 }
 
 static gboolean
@@ -343,7 +358,7 @@ proctable_new (ProcData * const procdata)
     gtk_tree_view_column_set_resizable (column, TRUE);
     gtk_tree_view_column_set_sizing(column, GTK_TREE_VIEW_COLUMN_FIXED);
     gtk_tree_view_column_set_min_width (column, 1);
-    g_signal_connect(G_OBJECT(column), "notify::width", G_CALLBACK(cb_proctable_column_resized), NULL);
+    g_signal_connect(G_OBJECT(column), "notify::fixed-width", G_CALLBACK(cb_proctable_column_resized), procdata->settings);
     gtk_tree_view_append_column (GTK_TREE_VIEW (proctree), column);
     gtk_tree_view_set_expander_column (GTK_TREE_VIEW (proctree), column);
 
@@ -359,7 +374,7 @@ proctable_new (ProcData * const procdata)
         gtk_tree_view_column_set_title(col, _(titles[i]));
         gtk_tree_view_column_set_resizable(col, TRUE);
         gtk_tree_view_column_set_sort_column_id(col, i);
-        g_signal_connect(G_OBJECT(col), "notify::width", G_CALLBACK(cb_proctable_column_resized), NULL);
+        g_signal_connect(G_OBJECT(col), "notify::fixed-width", G_CALLBACK(cb_proctable_column_resized), procdata->settings);
         gtk_tree_view_column_set_reorderable(col, TRUE);
         gtk_tree_view_append_column(GTK_TREE_VIEW(proctree), col);
 


### PR DESCRIPTION
fixes eating CPU and slowdowns during columns resizing

adapted from
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=89931e2e24df517e1c86929a64d4fcde55d599a7

@clefebvre @flexiondotorg @raveit65 
please test for any possible regressions :smile: