### PR TITLE
GTK3: Replaced sysinfo gtk tables with gtk grids

### DIFF
--- a/src/sysinfo.cpp
+++ b/src/sysinfo.cpp
@@ -693,9 +693,15 @@ add_section(GtkBox *vbox , const char * title, int num_row, int num_col, GtkWidg
     gtk_alignment_set_padding(GTK_ALIGNMENT(alignment), 0, 0, 12, 0);
     gtk_container_add(GTK_CONTAINER(frame), alignment);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+    table = gtk_grid_new();
+    gtk_grid_set_row_spacing(GTK_GRID(table), 6);
+    gtk_grid_set_column_spacing(GTK_GRID(table), 6);
+#else
     table = gtk_table_new(num_row, num_col, FALSE);
     gtk_table_set_row_spacings(GTK_TABLE(table), 6);
     gtk_table_set_col_spacings(GTK_TABLE(table), 6);
+#endif
     gtk_container_set_border_width(GTK_CONTAINER(table), 6);
     gtk_container_add(GTK_CONTAINER(alignment), table);
 
@@ -707,26 +713,42 @@ add_section(GtkBox *vbox , const char * title, int num_row, int num_col, GtkWidg
 
 
 static GtkWidget*
+#if GTK_CHECK_VERSION (3, 0, 0)
+add_row(GtkGrid * table, const char * label, const char * value, int row)
+#else
 add_row(GtkTable * table, const char * label, const char * value, int row)
+#endif
 {
     GtkWidget *header = gtk_label_new(NULL);
     gtk_label_set_markup(GTK_LABEL(header), label);
     gtk_label_set_selectable(GTK_LABEL(header), TRUE);
     gtk_misc_set_alignment(GTK_MISC(header), 0.0, 0.5);
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_grid_attach(
+        table, header,
+        0, row, 1, 1);
+#else
     gtk_table_attach(
         table, header,
         0, 1, row, row + 1,
         GTK_FILL, GTK_FILL, 0, 0
         );
+#endif
 
     GtkWidget *label_widget = gtk_label_new(value);
     gtk_label_set_selectable(GTK_LABEL(label_widget), TRUE);
     gtk_misc_set_alignment(GTK_MISC(label_widget), 0.0, 0.5);
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_grid_attach(
+        table, label_widget,
+        1, row, 1, 1);
+#else
     gtk_table_attach(
         table, label_widget,
         1, 2, row, row + 1,
         GTK_FILL, GTK_FILL, 0, 0
         );
+#endif
     return label_widget;
 }
 
@@ -803,11 +825,17 @@ procman_create_sysinfo_view(void)
     distro_release_label = gtk_label_new("???");
     gtk_label_set_selectable(GTK_LABEL(distro_release_label), TRUE);
     gtk_misc_set_alignment(GTK_MISC(distro_release_label), 0.0, 0.5);
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_grid_attach(
+        GTK_GRID(distro_table), distro_release_label,
+        0, table_count, 1, 1);
+#else
     gtk_table_attach(
         GTK_TABLE(distro_table), distro_release_label,
         0, 1, table_count, table_count+1,
         GTK_FILL, GTK_FILL, 0, 0
         );
+#endif
     table_count++;
     data->set_distro_labels(gtk_frame_get_label_widget(GTK_FRAME(distro_frame)), distro_release_label);
 
@@ -816,11 +844,17 @@ procman_create_sysinfo_view(void)
     gtk_label_set_selectable(GTK_LABEL(header), TRUE);
     g_free(markup);
     gtk_misc_set_alignment(GTK_MISC(header), 0.0, 0.5);
+#if GTK_CHECK_VERSION (3, 0, 0)
+    gtk_grid_attach(
+        GTK_GRID(distro_table), header,
+        0, table_count, 1, 1);
+#else
     gtk_table_attach(
         GTK_TABLE(distro_table), header,
         0, 1, table_count, table_count + 1,
         GTK_FILL, GTK_FILL, 0, 0
         );
+#endif
     table_count++;
 
     if (data->mate_version != "")
@@ -830,11 +864,17 @@ procman_create_sysinfo_view(void)
         gtk_label_set_selectable(GTK_LABEL(header), TRUE);
         g_free(markup);
         gtk_misc_set_alignment(GTK_MISC(header), 0.0, 0.5);
+#if GTK_CHECK_VERSION (3, 0, 0)
+        gtk_grid_attach(
+            GTK_GRID(distro_table), header,
+            0, table_count, 1, 1);
+#else
         gtk_table_attach(
             GTK_TABLE(distro_table), header,
             0, 1, table_count, table_count + 1,
             GTK_FILL, GTK_FILL, 0, 0
             );
+#endif
         table_count++;
     }
 
@@ -845,11 +885,19 @@ procman_create_sysinfo_view(void)
     g_free(markup);
 
     markup = procman::format_size(data->memory_bytes);
+#if GTK_CHECK_VERSION (3, 0, 0)
+    add_row(GTK_GRID(hardware_table), _("Memory:"), markup, 0);
+#else
     add_row(GTK_TABLE(hardware_table), _("Memory:"), markup, 0);
+#endif
     g_free(markup);
 
     markup = NULL;
+#if GTK_CHECK_VERSION (3, 0, 0)
+    add_row(GTK_GRID(hardware_table), _("Processor:"),
+#else
     add_row(GTK_TABLE(hardware_table), _("Processor:"),
+#endif
             data->processors.c_str(), 1);
 
     if(markup)
@@ -862,7 +910,11 @@ procman_create_sysinfo_view(void)
     g_free(markup);
 
     markup = procman::format_size(data->free_space_bytes);
+#if GTK_CHECK_VERSION (3, 0, 0)
+    add_row(GTK_GRID(disk_space_table), _("Available disk space:"), markup, 0);
+#else
     add_row(GTK_TABLE(disk_space_table), _("Available disk space:"), markup, 0);
+#endif
     g_free(markup);
 
     return hbox;


### PR DESCRIPTION
taken from: https://git.gnome.org/browse/gnome-system-monitor/commit/?id=5047e43