### PR TITLE
Do not use deprecated API

### DIFF
--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -250,12 +250,22 @@ cb_end_process_button_pressed (GtkButton *button, gpointer data)
 static void change_settings_color(GSettings *settings, const char *key,
                    GSMColorButton *cp)
 {
+#if GTK_CHECK_VERSION(3,0,0)
+    GdkRGBA c;
+    char *color;
+
+    gsm_color_button_get_color(cp, &c);
+    color = gdk_rgba_to_string (&c);
+    g_settings_set_string (settings, key, color);
+    g_free (color);
+#else
     GdkColor c;
     char color[24]; /* color should be 1 + 3*4 + 1 = 15 chars -> 24 */
 
     gsm_color_button_get_color(cp, &c);
     g_snprintf(color, sizeof color, "#%04x%04x%04x", c.red, c.green, c.blue);
     g_settings_set_string (settings, key, color);
+#endif
 }
 
 

--- a/src/gsm_color_button.h
+++ b/src/gsm_color_button.h
@@ -25,10 +25,9 @@
 #include <glib.h>
 #include <gdk/gdk.h>
 #include <gtk/gtk.h>
+#if !GTK_CHECK_VERSION(3,0,0)
 #include <cairo.h>
 #include <librsvg/rsvg.h>
-#ifndef RSVG_CAIRO_H
-#include <librsvg/rsvg-cairo.h>
 #endif
 
 G_BEGIN_DECLS
@@ -80,11 +79,20 @@ struct _GSMColorButtonClass
 };
 
 GType gsm_color_button_get_type (void) G_GNUC_CONST;
+#if GTK_CHECK_VERSION(3,0,0)
+GtkWidget *gsm_color_button_new (const GdkRGBA * color, guint type);
+void gsm_color_button_set_color (GSMColorButton * color_button, const GdkRGBA * color);
+#else
 GtkWidget *gsm_color_button_new (const GdkColor * color, guint type);
 void gsm_color_button_set_color (GSMColorButton * color_button, const GdkColor * color);
+#endif
 void gsm_color_button_set_fraction (GSMColorButton * color_button, const gdouble fraction);
 void gsm_color_button_set_cbtype (GSMColorButton * color_button, guint type);
+#if GTK_CHECK_VERSION(3,0,0)
+void gsm_color_button_get_color (GSMColorButton * color_button, GdkRGBA * color);
+#else
 void gsm_color_button_get_color (GSMColorButton * color_button, GdkColor * color);
+#endif
 gdouble gsm_color_button_get_fraction (GSMColorButton * color_button);
 guint gsm_color_button_get_cbtype (GSMColorButton * color_button);
 void gsm_color_button_set_title (GSMColorButton * color_button, const gchar * title);

--- a/src/load-graph.h
+++ b/src/load-graph.h
@@ -58,7 +58,11 @@ struct LoadGraph {
     double graph_delx;
     guint graph_buffer_offset;
 
+#if GTK_CHECK_VERSION(3,0,0)
+    std::vector<GdkRGBA> colors;
+#else
     std::vector<GdkColor> colors;
+#endif
 
     std::vector<float> data_block;
     gfloat* data[NUM_POINTS];

--- a/src/procman.cpp
+++ b/src/procman.cpp
@@ -195,26 +195,46 @@ color_changed_cb (GSettings *settings, const gchar *key, gpointer data)
         for (int i = 0; i < procdata->config.num_cpus; i++) {
             string cpu_key = make_string(g_strdup_printf("cpu-color%d", i));
             if (cpu_key == key) {
+#if GTK_CHECK_VERSION(3,0,0)
+                gdk_rgba_parse (&procdata->config.cpu_color[i], color);
+#else
                 gdk_color_parse (color, &procdata->config.cpu_color[i]);
+#endif
                 procdata->cpu_graph->colors.at(i) = procdata->config.cpu_color[i];
                 break;
             }
         }
     }
     else if (g_str_equal (key, "mem-color")) {
+#if GTK_CHECK_VERSION(3,0,0)
+        gdk_rgba_parse (&procdata->config.mem_color, color);
+#else
         gdk_color_parse (color, &procdata->config.mem_color);
+#endif
         procdata->mem_graph->colors.at(0) = procdata->config.mem_color;
     }
     else if (g_str_equal (key, "swap-color")) {
+#if GTK_CHECK_VERSION(3,0,0)
+        gdk_rgba_parse (&procdata->config.swap_color, color);
+#else
         gdk_color_parse (color, &procdata->config.swap_color);
+#endif
         procdata->mem_graph->colors.at(1) = procdata->config.swap_color;
     }
     else if (g_str_equal (key, "net-in-color")) {
+#if GTK_CHECK_VERSION(3,0,0)
+        gdk_rgba_parse (&procdata->config.net_in_color, color);
+#else
         gdk_color_parse (color, &procdata->config.net_in_color);
+#endif
         procdata->net_graph->colors.at(0) = procdata->config.net_in_color;
     }
     else if (g_str_equal (key, "net-out-color")) {
+#if GTK_CHECK_VERSION(3,0,0)
+        gdk_rgba_parse (&procdata->config.net_out_color, color);
+#else
         gdk_color_parse (color, &procdata->config.net_out_color);
+#endif
         procdata->net_graph->colors.at(1) = procdata->config.net_out_color;
     }
     else {
@@ -309,7 +329,11 @@ procman_data_new (GSettings *settings)
         detail_string = std::string("changed::") + std::string(key);
         g_signal_connect (G_OBJECT(settings), detail_string.c_str(),
                           G_CALLBACK(color_changed_cb), pd);
+#if GTK_CHECK_VERSION(3,0,0)
+        gdk_rgba_parse (&pd->config.cpu_color[i], color);
+#else
         gdk_color_parse(color, &pd->config.cpu_color[i]);
+#endif
         g_free (color);
         g_free (key);
     }
@@ -319,7 +343,11 @@ procman_data_new (GSettings *settings)
         color = g_strdup ("#000000ff0082");
     g_signal_connect (G_OBJECT(settings), "changed::mem-color",
                       G_CALLBACK(color_changed_cb), pd);
+#if GTK_CHECK_VERSION(3,0,0)
+    gdk_rgba_parse (&pd->config.mem_color, color);
+#else
     gdk_color_parse(color, &pd->config.mem_color);
+#endif
 
     g_free (color);
 
@@ -328,7 +356,11 @@ procman_data_new (GSettings *settings)
         color = g_strdup ("#00b6000000ff");
     g_signal_connect (G_OBJECT(settings), "changed::swap-color",
                       G_CALLBACK(color_changed_cb), pd);
+#if GTK_CHECK_VERSION(3,0,0)
+    gdk_rgba_parse (&pd->config.swap_color, color);
+#else
     gdk_color_parse(color, &pd->config.swap_color);
+#endif
     g_free (color);
 
     color = g_settings_get_string (settings, "net-in-color");
@@ -336,7 +368,11 @@ procman_data_new (GSettings *settings)
         color = g_strdup ("#000000f200f2");
     g_signal_connect (G_OBJECT(settings), "changed::net-in-color",
                       G_CALLBACK(color_changed_cb), pd);
+#if GTK_CHECK_VERSION(3,0,0)
+    gdk_rgba_parse (&pd->config.net_in_color, color);
+#else
     gdk_color_parse(color, &pd->config.net_in_color);
+#endif
     g_free (color);
 
     color = g_settings_get_string (settings, "net-out-color");
@@ -344,7 +380,11 @@ procman_data_new (GSettings *settings)
         color = g_strdup ("#00f2000000c1");
     g_signal_connect (G_OBJECT(settings), "changed::net-out-color",
                       G_CALLBACK(color_changed_cb), pd);
+#if GTK_CHECK_VERSION(3,0,0)
+    gdk_rgba_parse (&pd->config.net_out_color, color);
+#else
     gdk_color_parse(color, &pd->config.net_out_color);
+#endif
     g_free (color);
 
     /* Sanity checks */

--- a/src/procman.h
+++ b/src/procman.h
@@ -96,6 +96,15 @@ struct ProcConfig
     int         disks_update_interval;
     gint        whose_process;
     gint        current_tab;
+#if GTK_CHECK_VERSION(3,0,0)
+    GdkRGBA     cpu_color[GLIBTOP_NCPU];
+    GdkRGBA     mem_color;
+    GdkRGBA     swap_color;
+    GdkRGBA     net_in_color;
+    GdkRGBA     net_out_color;
+    GdkRGBA     bg_color;
+    GdkRGBA     frame_color;
+#else
     GdkColor    cpu_color[GLIBTOP_NCPU];
     GdkColor    mem_color;
     GdkColor    swap_color;
@@ -103,6 +112,7 @@ struct ProcConfig
     GdkColor    net_out_color;
     GdkColor    bg_color;
     GdkColor    frame_color;
+#endif
     gint        num_cpus;
     bool solaris_mode;
     bool network_in_bits;


### PR DESCRIPTION
Namely, we make the following replacements:
* GtkStyle -> GtkStyleContext
* GdkColor -> GdkRGBA
* GtkColorSelectionDialog -> GtkColorChooserDialog

taken from....but adjusted:
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=7ac1c1c