### PR TITLE
GTK3: Drop use of deprecated treeview API. gtk_tree_view_set_rules_hint

### DIFF
--- a/src/disks.cpp
+++ b/src/disks.cpp
@@ -334,7 +334,9 @@ create_disk_view(ProcData *procdata)
     g_signal_connect(G_OBJECT(disk_tree), "row-activated", G_CALLBACK(open_dir), NULL);
     procdata->disk_list = disk_tree;
     gtk_container_add(GTK_CONTAINER(scrolled), disk_tree);
+#if !GTK_CHECK_VERSION(3,0,0)
     gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(disk_tree), TRUE);
+#endif
     g_object_unref(G_OBJECT(model));
 
     /* icon + device */

--- a/src/lsof.cpp
+++ b/src/lsof.cpp
@@ -248,8 +248,9 @@ void procman_lsof(ProcData *procdata)
 
     GtkWidget *tree = gtk_tree_view_new_with_model(GTK_TREE_MODEL(model));
     g_object_unref(model);
+#if !GTK_CHECK_VERSION(3,0,0)
     gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(tree), TRUE);
-
+#endif
 
     GtkTreeViewColumn *column;
     GtkCellRenderer *renderer;

--- a/src/memmaps.cpp
+++ b/src/memmaps.cpp
@@ -344,7 +344,9 @@ create_memmapsdata (ProcData *procdata)
                                 );
 
     tree = gtk_tree_view_new_with_model (GTK_TREE_MODEL (model));
+#if !GTK_CHECK_VERSION(3,0,0)
     gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (tree), TRUE);
+#endif
     g_object_unref (G_OBJECT (model));
 
     for (i = 0; i < MMAP_COL_MAX; i++) {

--- a/src/openfiles.cpp
+++ b/src/openfiles.cpp
@@ -260,7 +260,9 @@ create_openfiles_tree (ProcData *procdata)
         );
 
     tree = gtk_tree_view_new_with_model (GTK_TREE_MODEL (model));
+#if !GTK_CHECK_VERSION(3,0,0)
     gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (tree), TRUE);
+#endif
     g_object_unref (G_OBJECT (model));
 
     for (i = 0; i < NUM_OPENFILES_COL-1; i++) {

--- a/src/procproperties.cpp
+++ b/src/procproperties.cpp
@@ -185,7 +185,9 @@ create_procproperties_tree (ProcData *procdata)
         );
 
     tree = gtk_tree_view_new_with_model (GTK_TREE_MODEL (model));
+#if !GTK_CHECK_VERSION(3,0,0)
     gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (tree), TRUE);
+#endif
     g_object_unref (G_OBJECT (model));
 
     for (i = 0; i < NUM_COLS; i++) {

--- a/src/proctable.cpp
+++ b/src/proctable.cpp
@@ -334,7 +334,9 @@ proctable_new (ProcData * const procdata)
                                          search_equal_func,
                                          NULL,
                                          NULL);
+#if !GTK_CHECK_VERSION(3,0,0)
     gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (proctree), TRUE);
+#endif
     g_object_unref (G_OBJECT (model));
 
     selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (proctree));


### PR DESCRIPTION
taken from:
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=7fefa84