### PR TITLE
Fixed adustments to only be set with a page_size of 0

### DIFF
--- a/src/procdialogs.cpp
+++ b/src/procdialogs.cpp
@@ -585,7 +585,7 @@ procdialog_create_preferences_dialog (ProcData *procdata)
                                    MAX_UPDATE_INTERVAL / 1000,
                                    0.25,
                                    1.0,
-                                   1.0);
+                                   0);
 
     spin_button = gtk_spin_button_new (adjustment, 1.0, 2);
     gtk_box_pack_start (GTK_BOX (hbox3), spin_button, FALSE, FALSE, 0);
@@ -695,7 +695,7 @@ procdialog_create_preferences_dialog (ProcData *procdata)
 
     update = (gfloat) procdata->config.graph_update_interval;
     adjustment = (GtkAdjustment *) gtk_adjustment_new(update / 1000.0, 0.25,
-                                                      100.0, 0.25, 1.0, 1.0);
+                                                      100.0, 0.25, 1.0, 0);
     spin_button = gtk_spin_button_new (adjustment, 1.0, 2);
     g_signal_connect (G_OBJECT (spin_button), "focus_out_event",
                       G_CALLBACK(SBU::callback),
@@ -756,7 +756,7 @@ procdialog_create_preferences_dialog (ProcData *procdata)
 
     update = (gfloat) procdata->config.disks_update_interval;
     adjustment = (GtkAdjustment *) gtk_adjustment_new (update / 1000.0, 1.0,
-                                                       100.0, 1.0, 1.0, 1.0);
+                                                       100.0, 1.0, 1.0, 0);
     spin_button = gtk_spin_button_new (adjustment, 1.0, 0);
     gtk_box_pack_start (GTK_BOX (hbox3), spin_button, FALSE, FALSE, 0);
     gtk_label_set_mnemonic_widget (GTK_LABEL (label), spin_button);


### PR DESCRIPTION
* Setting an adjustment with non-zero page size is deprecated

taken from:
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=9ff48dc