### PR TITLE
run gksu binary instead of loading libgksu2.so (which is GTK+2 only)

### DIFF
--- a/src/procman_gksu.cpp
+++ b/src/procman_gksu.cpp
@@ -2,53 +2,32 @@
 
 #include "procman.h"
 #include "procman_gksu.h"
-#include "util.h"
 
-static gboolean (*gksu_run)(const char *, GError **);
-
-
-static void load_gksu(void)
+gboolean
+procman_gksu_create_root_password_dialog (const char *command)
 {
-    static gboolean init;
+    gchar *command_line;
+    gboolean success;
+    GError *error = NULL;
 
-    if (init)
-        return;
+    command_line = g_strdup_printf ("gksu '%s'", command);
+    success = g_spawn_command_line_sync (command_line, NULL, NULL, NULL, &error);
+    g_free (command_line);
 
-    init = TRUE;
-
-    load_symbols("libgksu2.so",
-                 "gksu_run", &gksu_run,
-                 NULL);
-}
-
-
-
-
-
-gboolean procman_gksu_create_root_password_dialog(const char *command)
-{
-    GError *e = NULL;
-
-    /* Returns FALSE or TRUE on success, depends on version ... */
-    gksu_run(command, &e);
-
-    if (e) {
-        g_critical("Could not run gksu_run(\"%s\") : %s\n",
-                   command, e->message);
-        g_error_free(e);
+    if (!success) {
+        g_critical ("Could not run gksu '%s' : %s\n",
+                    command, error->message);
+        g_error_free (error);
         return FALSE;
     }
 
-    g_message("gksu_run did fine\n");
+    g_debug ("gksu did fine\n");
     return TRUE;
 }
 
-
-
 gboolean
-procman_has_gksu(void)
+procman_has_gksu (void)
 {
-    load_gksu();
-    return gksu_run != NULL;
+    return g_file_test ("/usr/bin/gksu", G_FILE_TEST_EXISTS);
 }
 


### PR DESCRIPTION
This will avoid crashing when trying to kill/renice another user's process. We can't load symbols from libgksu2.so anymore as m-s-m is GTK+3 only now.

How to test: select "All Processes" in View menu, then right-click on another user's process and try to renice it. You should see gksu dialog appearing. Well, you can try testing it with kill as well, but that's at your own risk. :smile:


@flexiondotorg @clefebvre @raveit65 @posophe @XRevan86 @willysr @obache 
Note: if m-s-m package in your distros depends on/recommends/suggests ```libgksu2```, it should be changed to ```gksu``` after this.