### PR TITLE
add pkexec support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@
 
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
-SUBDIRS = pixmaps po src help
+SUBDIRS = pixmaps po src tools help
 
 man_MANS = mate-system-monitor.1
 
@@ -11,16 +11,25 @@ appdatadir = $(datadir)/appdata
 appdata_in_files = mate-system-monitor.appdata.xml.in
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 
+org.mate.mate-system-monitor.policy.in: org.mate.mate-system-monitor.policy.in.in Makefile
+	$(AM_V_GEN) sed -e "s|\@pkglibexecdir\@|$(pkglibexecdir)|" $< > $@
+
 EXTRA_DIST = \
 	autogen.sh \
 	$(man_MANS) \
 	$(appdata_in_files) \
+	org.mate.mate-system-monitor.policy.in.in \
 	mate-system-monitor.desktop.in \
 	intltool-extract.in \
 	intltool-merge.in \
 	intltool-update.in \
 	omf.make \
 	xmldocs.make
+
+@INTLTOOL_POLICY_RULE@
+polkit_policydir = $(datadir)/polkit-1/actions
+polkit_policy_in_files = org.mate.mate-system-monitor.policy.in
+polkit_policy_DATA = $(polkit_policy_in_files:.policy.in=.policy)
 
 Applicationsdir = $(datadir)/applications
 Applications_in_files = mate-system-monitor.desktop.in
@@ -35,7 +44,9 @@ DISTCLEANFILES = \
   intltool-extract \
   intltool-merge \
   intltool-update \
-  mate-system-monitor.desktop
+  mate-system-monitor.desktop \
+  org.mate.mate-system-monitor.policy \
+  org.mate.mate-system-monitor.policy.in
 
 # Build ChangeLog from GIT  history
 ChangeLog:

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,8 @@ AC_DEFINE([GLIB_VERSION_MIN_REQUIRED], [GLIB_VERSION_2_36],
 PKG_CHECK_MODULES(GMODULE,gmodule-2.0,[GMODULE_ADD="gmodule-2.0"],[GMODULE_ADD=""])
 PKG_CHECK_MODULES(PROCMAN,$GMODULE_ADD glib-2.0 >= $GLIB_REQUIRED libgtop-2.0 >= $LIBGTOP_REQUIRED libwnck-3.0 >= $LIBWNCK_REQUIRED gtk+-3.0 >= $GTK_REQUIRED gtkmm-3.0 >= $GTKMM_REQUIRED libxml-2.0 >= $LIBXML_REQUIRED librsvg-2.0 >= $RSVG_REQUIRED glibmm-2.4 >= $GLIBMM_REQUIRED giomm-2.4 >= $GIOMM_REQUIRED)
 
+PKG_CHECK_MODULES(TOOLS, glib-2.0 >= $GLIB_REQUIRED)
+
 have_systemd=no
 AC_ARG_ENABLE(systemd, AS_HELP_STRING([--disable-systemd], [disable systemd support]),,enable_systemd=no)
 if test "x$enable_systemd" != "xno"; then
@@ -107,6 +109,7 @@ src/org.mate.system-monitor.gschema.xml
 pixmaps/Makefile
 po/Makefile.in
 help/Makefile
+tools/Makefile
 mate-system-monitor.desktop.in
 ])
 

--- a/org.mate.mate-system-monitor.policy.in.in
+++ b/org.mate.mate-system-monitor.policy.in.in
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <vendor>MATE Desktop</vendor>
+  <vendor_url>http://www.mate-desktop.org/</vendor_url>
+  <icon_name>utilities-system-monitor</icon_name>
+
+  <action id="org.mate.mate-system-monitor.kill">
+    <_description>Kill process</_description>
+    <_message>Privileges are required to control other users' processes</_message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">@pkglibexecdir@/msm-kill</annotate>
+  </action>
+
+  <action id="org.mate.mate-system-monitor.renice">
+    <_description>Renice process</_description>
+    <_message>Privileges are required to change the priority of processes</_message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">@pkglibexecdir@/msm-renice</annotate>
+  </action>
+
+</policyconfig>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -3,6 +3,7 @@
 # Please keep this file sorted alphabetically.
 mate-system-monitor.appdata.xml.in
 mate-system-monitor.desktop.in.in
+org.mate.mate-system-monitor.policy.in.in
 src/argv.cpp
 src/argv.h
 src/callbacks.cpp

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,1 +1,2 @@
 mate-system-monitor.desktop.in
+org.mate.mate-system-monitor.policy.in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,6 +4,7 @@ AM_CPPFLAGS = \
 	-DPROCMAN_DATADIR=\""$(datadir)/procman/"\" \
 	-DMATELOCALEDIR=\""$(datadir)/locale"\" \
 	-DDATADIR=\""$(datadir)"\" \
+	-DLIBEXEC_DIR=\""$(pkglibexecdir)"\" \
 	@PROCMAN_CFLAGS@ \
 	@SYSTEMD_CFLAGS@
 
@@ -28,6 +29,7 @@ mate_system_monitor_cpp_files = \
 	selinux.cpp \
 	cgroups.cpp \
 	procman_gksu.cpp \
+	procman_pkexec.cpp \
 	sysinfo.cpp \
 	lsof.cpp \
 	selection.cpp \

--- a/src/procdialogs.cpp
+++ b/src/procdialogs.cpp
@@ -34,6 +34,7 @@
 #include "load-graph.h"
 #include "settings-keys.h"
 #include "procman_gksu.h"
+#include "procman_pkexec.h"
 #include "cgroups.h"
 
 
@@ -894,7 +895,9 @@ procdialog_create_root_password_dialog(ProcmanActionType type,
 
     procman_debug("Trying to run '%s' as root", command);
 
-    if (procman_has_gksu())
+    if (procman_has_pkexec())
+        ret = procman_pkexec_create_root_password_dialog(command);
+    else if (procman_has_gksu())
         ret = procman_gksu_create_root_password_dialog(command);
 
     g_free(command);

--- a/src/procman_pkexec.cpp
+++ b/src/procman_pkexec.cpp
@@ -1,0 +1,33 @@
+#include <config.h>
+
+#include "procman_pkexec.h"
+
+gboolean
+procman_pkexec_create_root_password_dialog (const char *command)
+{
+    gchar *command_line;
+    gboolean success;
+    GError *error = NULL;
+
+    command_line = g_strdup_printf ("pkexec --disable-internal-agent %s/msm-%s",
+                                    LIBEXEC_DIR, command);
+    success = g_spawn_command_line_sync (command_line, NULL, NULL, NULL, &error);
+    g_free (command_line);
+
+    if (!success) {
+        g_critical ("Could not run pkexec (\"%s\") : %s\n",
+                    command, error->message);
+        g_error_free (error);
+        return FALSE;
+    }
+
+    g_debug ("pkexec did fine\n");
+    return TRUE;
+}
+
+gboolean
+procman_has_pkexec (void)
+{
+    return g_file_test("/usr/bin/pkexec", G_FILE_TEST_EXISTS);
+}
+

--- a/src/procman_pkexec.h
+++ b/src/procman_pkexec.h
@@ -1,0 +1,12 @@
+#ifndef _PROCMAN_PKEXEC_H_
+#define _PROCMAN_PKEXEC_H_
+
+#include <glib.h>
+
+gboolean
+procman_pkexec_create_root_password_dialog(const char *command);
+
+gboolean
+procman_has_pkexec(void) G_GNUC_CONST;
+
+#endif /* _PROCMAN_PKEXEC_H_ */

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,0 +1,12 @@
+pkglibexec_PROGRAMS = msm-renice msm-kill
+
+AM_CPPFLAGS = $(TOOLS_CFLAGS)
+
+msm_renice_SOURCES = msm_execute_helper.c
+msm_renice_LDADD = $(TOOLS_LIBS)
+msm_renice_CFLAGS = -DCOMMAND=\"renice\"
+
+msm_kill_SOURCES = msm_execute_helper.c
+msm_kill_LDADD = $(TOOLS_LIBS)
+msm_kill_CFLAGS = -DCOMMAND=\"kill\"
+

--- a/tools/msm_execute_helper.c
+++ b/tools/msm_execute_helper.c
@@ -1,0 +1,17 @@
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <glib.h>
+
+int main(int argc, char* argv[])
+{
+    gchar **argv_modified = g_new0 (gchar *, argc + 1);
+    memcpy (argv_modified, argv, argc * sizeof (char*));
+    argv_modified[0] = COMMAND;
+
+    if (execvp (COMMAND, argv_modified) == -1) {
+        return errno;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
closes https://github.com/mate-desktop/mate-system-monitor/issues/85

try pkexec before trying gksu for killing other users' processes
or renicing a process. actual kill and renice commands are launched
via helper tool (see discussion at https://bugzilla.gnome.org/491462).

code is ported from gnome-system-monitor with some changes (e.g. helper
tool code is in tools/ dir instead of scripts/ - it's not a script).

for reference - relevant upstream commits:
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=ccbff2a4293e43d6ea24fbf13477b10f58cd5212
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=2b4308d9fc2b2e367030629e79b531c4f9ae3d0a
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=971b3c704dea49b22c1038f200933c5b3b35ece1
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=c234b2a75dac454b818f1f40d302cf12f1a33aa2
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=4cda3529e418098b35f7444d79ba421eb5403afc
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=ab7bd8aef7300eeb3835fdef9a2a1eefe7281631
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=79eccf0cecbca237f4f911681438c33932da63e2
https://git.gnome.org/browse/gnome-system-monitor/commit/?id=a3bf3a7f56cf02c6a127aa168c570230e9fad356

@raveit65 @lukefromdc @sc0w @XRevan86 please test it if you can guys.

renice test:
- enable All Processes in View menu
- right-click on your process -> Change Priority -> select some higher priority
- right-click on process of another user -> Change Priority -> select any priority

kill test:
- enable All Processes in View menu
- right-click on process of another user -> choose End Process or Kill Process -> confirm the action

In both cases you should see polkit's dialog instead of gksu's one. For distros that don't have gksu there would be an error message previously... well, now there should be polkit's dialog :smile: