### PR TITLE
sysinfo.cpp: Fix build warning: this ‘if’ clause does not guard this statement

### DIFF
--- a/src/sysinfo.cpp
+++ b/src/sysinfo.cpp
@@ -485,7 +485,7 @@ namespace {
             if (error)
                 g_error_free(error);
 
-                g_free(out);
+            g_free(out);
         }
 
     private:


### PR DESCRIPTION
NOTE: seems we have this bad indentation since the commit: https://github.com/mate-desktop/mate-system-monitor/commit/12975909c589880030db6125ad6dcbea889edcdc