### PR TITLE
procman.cpp: Fix build warning: argument 1 null where non-null expected

### DIFF
--- a/src/procman.cpp
+++ b/src/procman.cpp
@@ -596,14 +596,10 @@ cb_server (const gchar *msg, gpointer user_data)
             procman_debug("Changing to PROCMAN_TAB_DISKS via bacon message");
             set_tab(GTK_NOTEBOOK(procdata->notebook), PROCMAN_TAB_DISKS, procdata);
         }
-    } else
-        timestamp = strtoul(msg, NULL, 0);
-
-    if (timestamp == 0)
-    {
-        /* fall back to rountripping to X */
-        timestamp = gdk_x11_get_server_time (window);
     }
+
+    /* fall back to rountripping to X */
+    timestamp = gdk_x11_get_server_time (window);
 
     gdk_x11_window_set_user_time (window, timestamp);
 


### PR DESCRIPTION
without the PR:

```
if (msg != NULL) {
...
...
} else
    timestamp = strtoul(msg, NULL, 0);
```

`msg` works as `NULL`, I think if this line is called, it makes a `Segmentation fault`, it is useless, so I removed it

NOTE: I think this warning was introduced by the commit https://github.com/mate-desktop/mate-system-monitor/commit/120ef9172463db2778b4790baa8ba7ae650aa247