### PR TITLE
Ignore tun/tap network interfaces when calculating network total recieved and sent

### DIFF
--- a/src/load-graph.cpp
+++ b/src/load-graph.cpp
@@ -1,5 +1,7 @@
 #include <config.h>
 
+#include <chrono> // TEMPORARY
+
 #include <gdkmm/pixbuf.h>
 
 #include <stdio.h>
@@ -557,10 +559,14 @@ get_net (LoadGraph *graph)
 
         /* Skip tun and tap interfaces */
 #ifdef __linux__
-        char path[strlen(ifnames[i]) + 25];
+        auto start = std::chrono::high_resolution_clock::now();
+        char path[strlen(ifnames[i]) + 26];
         sprintf(path, "/sys/class/net/%s/tun_flags", ifnames[i]);
         if (!access(path, F_OK))
             continue;
+        auto finish = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> elapsed = finish - start;
+        printf("Time elapsed: %f\n", elapsed.count());
 #else
         int ifnamelen = strlen(ifnames[i]);
         if (ifnamelen >= 4)

--- a/src/load-graph.cpp
+++ b/src/load-graph.cpp
@@ -555,6 +555,22 @@ get_net (LoadGraph *graph)
             and not (netload.flags & (1 << GLIBTOP_NETLOAD_ADDRESS)))
             continue;
 
+        /* Skip tun and tap interfaces */
+        int ifnamelen = strlen(ifnames[i]);
+        if(ifnamelen >= 4) {
+            char sub[4];
+            memcpy(sub, ifnames[i], 3);
+            sub[3] = '\0';
+            if(strcmp(sub, "tun") || strcmp(sub, "tap")) {
+                bool cont = false;
+                for(int j = 3; j < ifnamelen - 1; ++j)
+                    if(!isdigit((int)((ifnames[i])[j])))
+                        cont = true;
+                if(!cont)
+                    continue;
+            }
+        }
+
         /* Don't skip interfaces that are down (GLIBTOP_IF_FLAGS_UP)
            to avoid spikes when they are brought up */
 

--- a/src/load-graph.cpp
+++ b/src/load-graph.cpp
@@ -1,7 +1,5 @@
 #include <config.h>
 
-#include <chrono> // TEMPORARY
-
 #include <gdkmm/pixbuf.h>
 
 #include <stdio.h>
@@ -559,14 +557,10 @@ get_net (LoadGraph *graph)
 
         /* Skip tun and tap interfaces */
 #ifdef __linux__
-        auto start = std::chrono::high_resolution_clock::now();
         char path[strlen(ifnames[i]) + 26];
         sprintf(path, "/sys/class/net/%s/tun_flags", ifnames[i]);
         if (!access(path, F_OK))
             continue;
-        auto finish = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double> elapsed = finish - start;
-        printf("Time elapsed: %f\n", elapsed.count());
 #else
         int ifnamelen = strlen(ifnames[i]);
         if (ifnamelen >= 4)

--- a/src/load-graph.cpp
+++ b/src/load-graph.cpp
@@ -557,16 +557,18 @@ get_net (LoadGraph *graph)
 
         /* Skip tun and tap interfaces */
         int ifnamelen = strlen(ifnames[i]);
-        if(ifnamelen >= 4) {
+        if (ifnamelen >= 4)
+        {
             char sub[4];
             memcpy(sub, ifnames[i], 3);
             sub[3] = '\0';
-            if(strcmp(sub, "tun") || strcmp(sub, "tap")) {
+            if (strcmp(sub, "tun") || strcmp(sub, "tap"))
+            {
                 bool cont = false;
-                for(int j = 3; j < ifnamelen - 1; ++j)
-                    if(!isdigit((int)((ifnames[i])[j])))
+                for (int j = 3; j < ifnamelen - 1; ++j)
+                    if (!isdigit((int)((ifnames[i])[j])))
                         cont = true;
-                if(!cont)
+                if (!cont)
                     continue;
             }
         }

--- a/src/load-graph.cpp
+++ b/src/load-graph.cpp
@@ -565,7 +565,7 @@ get_net (LoadGraph *graph)
         int ifnamelen = strlen(ifnames[i]);
         if (ifnamelen >= 4)
         {
-            if (strncmp(ifnames[i], "tun", 3) || strncmp(ifnames[i], "tap", 3))
+            if (!strncmp(ifnames[i], "tun", 3) || !strncmp(ifnames[i], "tap", 3))
             {
                 bool cont = false;
                 for (int j = 3; j < ifnamelen - 1; ++j)

--- a/src/load-graph.cpp
+++ b/src/load-graph.cpp
@@ -563,17 +563,14 @@ get_net (LoadGraph *graph)
             continue;
 #else
         int ifnamelen = strlen(ifnames[i]);
-        if (ifnamelen >= 4)
+        if (!strncmp(ifnames[i], "tun", 3) || !strncmp(ifnames[i], "tap", 3))
         {
-            if (!strncmp(ifnames[i], "tun", 3) || !strncmp(ifnames[i], "tap", 3))
-            {
-                bool cont = false;
-                for (int j = 3; j < ifnamelen - 1; ++j)
-                    if (!isdigit((int)((ifnames[i])[j])))
-                        cont = true;
-                if (!cont)
-                    continue;
-            }
+            bool cont = false;
+            for (int j = 3; j < ifnamelen; ++j)
+                if (!isdigit((int)((ifnames[i])[j])))
+                    cont = true;
+            if (!cont)
+                continue;
         }
 #endif
 

--- a/src/load-graph.cpp
+++ b/src/load-graph.cpp
@@ -559,10 +559,7 @@ get_net (LoadGraph *graph)
         int ifnamelen = strlen(ifnames[i]);
         if (ifnamelen >= 4)
         {
-            char sub[4];
-            memcpy(sub, ifnames[i], 3);
-            sub[3] = '\0';
-            if (strcmp(sub, "tun") || strcmp(sub, "tap"))
+            if (strncmp(ifnames[i], "tun", 3) || strncmp(ifnames[i], "tap", 3))
             {
                 bool cont = false;
                 for (int j = 3; j < ifnamelen - 1; ++j)

--- a/src/load-graph.cpp
+++ b/src/load-graph.cpp
@@ -556,6 +556,12 @@ get_net (LoadGraph *graph)
             continue;
 
         /* Skip tun and tap interfaces */
+#ifdef __linux__
+        char path[strlen(ifnames[i]) + 25];
+        sprintf(path, "/sys/class/net/%s/tun_flags", ifnames[i]);
+        if (!access(path, F_OK))
+            continue;
+#else
         int ifnamelen = strlen(ifnames[i]);
         if (ifnamelen >= 4)
         {
@@ -569,6 +575,7 @@ get_net (LoadGraph *graph)
                     continue;
             }
         }
+#endif
 
         /* Don't skip interfaces that are down (GLIBTOP_IF_FLAGS_UP)
            to avoid spikes when they are brought up */


### PR DESCRIPTION
TUN/TAP devices are a feature of the Linux kernel which allow userspace applications to create virtual network interfaces. As such, they are not physical network devices and should not be used while calculating the total network usage since the system's boot.

This allows proper calculations for users of VPNs in particular.