### PR TITLE
Count bandwidth usage in bytes

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -588,7 +588,7 @@ namespace procman
 
     std::string format_network(guint64 rate, guint64 max_rate)
     {
-        char* bytes = procman::format_size(rate, max_rate, ProcData::get_instance()->config.network_in_bits);
+        char* bytes = procman::format_size(rate, max_rate, false);
         std::string formatted(bytes);
         g_free(bytes);
         return formatted;


### PR DESCRIPTION
In the Network History section of mate-system-monitor, currently, the "Total Recieved" and "Total Sent" values are calculated in bits if the "Show network speed in bits" option is enabled in Preferences. With this commit, those are always measured in bytes, even when the "Receiving" and "Sending" values are set to be measured in bits.