### PR TITLE
Avoid compile warning for g_type_class_add_private

### DIFF
--- a/src/gsm_color_button.c
+++ b/src/gsm_color_button.c
@@ -35,10 +35,7 @@
 
 #include "gsm_color_button.h"
 
-#define GSM_COLOR_BUTTON_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), GSM_TYPE_COLOR_BUTTON, GSMColorButtonPrivate))
-
-struct _GSMColorButtonPrivate
-{
+typedef struct {
     GtkWidget *cc_dialog;		/* Color chooser dialog */
 
     gchar *title;            /* Title for the color selection window */
@@ -51,7 +48,9 @@ struct _GSMColorButtonPrivate
     gdouble highlight;
     gboolean button_down;
     gboolean in_button;
-};
+} GSMColorButtonPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (GSMColorButton, gsm_color_button, GTK_TYPE_DRAWING_AREA)
 
 /* Properties */
 enum
@@ -125,43 +124,7 @@ static void gsm_color_button_drag_data_received (GtkWidget * widget,
 
 static guint color_button_signals[LAST_SIGNAL] = { 0 };
 
-static gpointer gsm_color_button_parent_class = NULL;
-
 static const GtkTargetEntry drop_types[] = { {"application/x-color", 0, 0} };
-
-GType
-gsm_color_button_get_type ()
-{
-    static GType gsm_color_button_type = 0;
-
-    if (!gsm_color_button_type)
-        {
-            static const GTypeInfo gsm_color_button_info = {
-                sizeof (GSMColorButtonClass),
-                NULL,
-                NULL,
-                (GClassInitFunc) gsm_color_button_class_intern_init,
-                NULL,
-                NULL,
-                sizeof (GSMColorButton),
-                0,
-               (GInstanceInitFunc) gsm_color_button_init,
-        };
-
-        gsm_color_button_type =
-            g_type_register_static (GTK_TYPE_DRAWING_AREA, "GSMColorButton",
-                                    &gsm_color_button_info, 0);
-    }
-
-    return gsm_color_button_type;
-}
-
-static void
-gsm_color_button_class_intern_init (gpointer klass)
-{
-    gsm_color_button_parent_class = g_type_class_peek_parent (klass);
-    gsm_color_button_class_init ((GSMColorButtonClass *) klass);
-}
 
 static void
 gsm_color_button_class_init (GSMColorButtonClass * klass)
@@ -231,7 +194,6 @@ gsm_color_button_class_init (GSMColorButtonClass * klass)
                                                     g_cclosure_marshal_VOID__VOID,
                                                     G_TYPE_NONE, 0);
 
-    g_type_class_add_private (gobject_class, sizeof (GSMColorButtonPrivate));
 }
 
 
@@ -267,9 +229,12 @@ fill_image_buffer_from_file (cairo_t *cr, const char *filePath)
 static void
 render (GtkWidget * widget)
 {
+    GSMColorButtonPrivate *priv;
     GSMColorButton *color_button = GSM_COLOR_BUTTON (widget);
+
+    priv = gsm_color_button_get_instance_private (color_button);
     GdkRGBA *color;
-    GdkRGBA tmp_color = color_button->priv->color;
+    GdkRGBA tmp_color = priv->color;
     color = &tmp_color;
     cairo_t *cr = gdk_cairo_create (gtk_widget_get_window (widget));
     cairo_path_t *path = NULL;
@@ -277,8 +242,8 @@ render (GtkWidget * widget)
     gdouble radius, arc_start, arc_end;
     gdouble highlight_factor;
 
-    if (color_button->priv->highlight > 0) {
-        highlight_factor = 0.125 * color_button->priv->highlight;
+    if (priv->highlight > 0) {
+        highlight_factor = 0.125 * priv->highlight;
 
     if (color->red + highlight_factor > 1.0)
         color->red = 1.0;
@@ -300,7 +265,7 @@ render (GtkWidget * widget)
     width = gdk_window_get_width(gtk_widget_get_window(widget));
     height = gdk_window_get_height(gtk_widget_get_window(widget));
 
-    switch (color_button->priv->type)
+    switch (priv->type)
         {
         case GSMCP_TYPE_CPU:
             //gtk_widget_set_size_request (widget, GSMCP_MIN_WIDTH, GSMCP_MIN_HEIGHT);
@@ -322,16 +287,16 @@ render (GtkWidget * widget)
             else
                 radius = height / 2;
 
-            arc_start = -G_PI_2 + 2 * G_PI * color_button->priv->fraction;
+            arc_start = -G_PI_2 + 2 * G_PI * priv->fraction;
             arc_end = -G_PI_2;
 
             cairo_set_line_width (cr, 1);
 
             // Draw external stroke and fill
-            if (color_button->priv->fraction < 0.01) {
+            if (priv->fraction < 0.01) {
                 cairo_arc (cr, (width / 2) + .5, (height / 2) + .5, 4.5,
                     0, 2 * G_PI);
-            } else if (color_button->priv->fraction > 0.99) {
+            } else if (priv->fraction > 0.99) {
                 cairo_arc (cr, (width / 2) + .5, (height / 2) + .5, radius - 2.25,
                     0, 2 * G_PI);
             } else {
@@ -350,10 +315,10 @@ render (GtkWidget * widget)
             cairo_set_source_rgba (cr, 1, 1, 1, 0.45);
             cairo_set_line_width (cr, 1);
 
-            if (color_button->priv->fraction < 0.03) {
+            if (priv->fraction < 0.03) {
                 cairo_arc (cr, (width / 2) + .5, (height / 2) + .5, 3.25,
                     0, 2 * G_PI);
-            } else if (color_button->priv->fraction > 0.99) {
+            } else if (priv->fraction > 0.99) {
                 cairo_arc (cr, (width / 2) + .5, (height / 2) + .5, radius - 3.5,
                     0, 2 * G_PI);
             } else {
@@ -378,8 +343,8 @@ render (GtkWidget * widget)
 
             break;
         case GSMCP_TYPE_NETWORK_IN:
-            if (color_button->priv->image_buffer == NULL)
-                color_button->priv->image_buffer =
+            if (priv->image_buffer == NULL)
+                priv->image_buffer =
                     fill_image_buffer_from_file (cr, DATADIR "/pixmaps/mate-system-monitor/download.svg");
             gtk_widget_set_size_request (widget, 32, 32);
             cairo_move_to (cr, 8.5, 1.5);
@@ -403,14 +368,14 @@ render (GtkWidget * widget)
             cairo_append_path (cr, path);
             cairo_path_destroy(path);
             cairo_stroke (cr);
-            cairo_set_source_surface (cr, color_button->priv->image_buffer, 0.0,
+            cairo_set_source_surface (cr, priv->image_buffer, 0.0,
                 0.0);
             cairo_paint (cr);
 
             break;
         case GSMCP_TYPE_NETWORK_OUT:
-            if (color_button->priv->image_buffer == NULL)
-                color_button->priv->image_buffer =
+            if (priv->image_buffer == NULL)
+                priv->image_buffer =
                 fill_image_buffer_from_file (cr, DATADIR "/pixmaps/mate-system-monitor/upload.svg");
             gtk_widget_set_size_request (widget, 32, 32);
             cairo_move_to (cr, 16.5, 1.5);
@@ -434,7 +399,7 @@ render (GtkWidget * widget)
             cairo_append_path (cr, path);
             cairo_path_destroy(path);
             cairo_stroke (cr);
-            cairo_set_source_surface (cr, color_button->priv->image_buffer, 0.0,
+            cairo_set_source_surface (cr, priv->image_buffer, 0.0,
                 0.0);
             cairo_paint (cr);
 
@@ -525,6 +490,9 @@ gsm_color_button_drag_data_received (GtkWidget * widget,
 {
     gint length;
     guint16 *dropped;
+    GSMColorButtonPrivate *priv;
+
+    priv = gsm_color_button_get_instance_private (color_button);
 
     length = gtk_selection_data_get_length (selection_data);
 
@@ -543,11 +511,11 @@ gsm_color_button_drag_data_received (GtkWidget * widget,
 
     dropped = (guint16 *) gtk_selection_data_get_data (selection_data);
 
-    color_button->priv->color.red = dropped[0];
-    color_button->priv->color.green = dropped[1];
-    color_button->priv->color.blue = dropped[2];
+    priv->color.red = dropped[0];
+    priv->color.green = dropped[1];
+    priv->color.blue = dropped[2];
 
-    gtk_widget_queue_draw (GTK_WIDGET (&color_button->widget));
+    gtk_widget_queue_draw (GTK_WIDGET(color_button));
 
     g_signal_emit (color_button, color_button_signals[COLOR_SET], 0);
 
@@ -579,9 +547,12 @@ static void
 gsm_color_button_drag_begin (GtkWidget * widget,
                              GdkDragContext * context, gpointer data)
 {
+    GSMColorButtonPrivate *priv;
     GSMColorButton *color_button = data;
 
-    set_color_icon (context, &color_button->priv->color);
+    priv = gsm_color_button_get_instance_private (color_button);
+
+    set_color_icon (context, &priv->color);
 }
 
 static void
@@ -592,10 +563,13 @@ gsm_color_button_drag_data_get (GtkWidget * widget,
                                 guint time, GSMColorButton * color_button)
 {
     guint16 dropped[4];
+    GSMColorButtonPrivate *priv;
 
-    dropped[0] = color_button->priv->color.red;
-    dropped[1] = color_button->priv->color.green;
-    dropped[2] = color_button->priv->color.blue;
+    priv = gsm_color_button_get_instance_private (color_button);
+
+    dropped[0] = priv->color.red;
+    dropped[1] = priv->color.green;
+    dropped[2] = priv->color.blue;
     dropped[3] = 65535;        // This widget doesn't care about alpha
 
     gtk_selection_data_set (selection_data, gtk_selection_data_get_target (selection_data),
@@ -606,17 +580,19 @@ gsm_color_button_drag_data_get (GtkWidget * widget,
 static void
 gsm_color_button_init (GSMColorButton * color_button)
 {
-    color_button->priv = GSM_COLOR_BUTTON_GET_PRIVATE (color_button);
+    GSMColorButtonPrivate *priv;
 
-    color_button->priv->color.red = 0;
-    color_button->priv->color.green = 0;
-    color_button->priv->color.blue = 0;
-    color_button->priv->fraction = 0.5;
-    color_button->priv->type = GSMCP_TYPE_CPU;
-    color_button->priv->image_buffer = NULL;
-    color_button->priv->title = g_strdup (_("Pick a Color"));     /* default title */
-    color_button->priv->in_button = FALSE;
-    color_button->priv->button_down = FALSE;
+    priv = gsm_color_button_get_instance_private (color_button);
+
+    priv->color.red = 0;
+    priv->color.green = 0;
+    priv->color.blue = 0;
+    priv->fraction = 0.5;
+    priv->type = GSMCP_TYPE_CPU;
+    priv->image_buffer = NULL;
+    priv->title = g_strdup (_("Pick a Color"));     /* default title */
+    priv->in_button = FALSE;
+    priv->button_down = FALSE;
 
     gtk_drag_dest_set (GTK_WIDGET (color_button),
                        GTK_DEST_DEFAULT_MOTION |
@@ -645,17 +621,20 @@ gsm_color_button_init (GSMColorButton * color_button)
 static void
 gsm_color_button_finalize (GObject * object)
 {
+    GSMColorButtonPrivate *priv;
     GSMColorButton *color_button = GSM_COLOR_BUTTON (object);
 
-    if (color_button->priv->cc_dialog != NULL)
-        gtk_widget_destroy (color_button->priv->cc_dialog);
-    color_button->priv->cc_dialog = NULL;
+    priv = gsm_color_button_get_instance_private (color_button);
 
-    g_free (color_button->priv->title);
-    color_button->priv->title = NULL;
+    if (priv->cc_dialog != NULL)
+        gtk_widget_destroy (priv->cc_dialog);
+    priv->cc_dialog = NULL;
 
-    cairo_surface_destroy (color_button->priv->image_buffer);
-    color_button->priv->image_buffer = NULL;
+    g_free (priv->title);
+    priv->title = NULL;
+
+    cairo_surface_destroy (priv->image_buffer);
+    priv->image_buffer = NULL;
 
     G_OBJECT_CLASS (gsm_color_button_parent_class)->finalize (object);
 }
@@ -670,17 +649,20 @@ gsm_color_button_new (const GdkRGBA * color, guint type)
 static void
 dialog_response (GtkWidget * widget, GtkResponseType response, gpointer data)
 {
+    GSMColorButtonPrivate *priv;
     GSMColorButton *color_button = GSM_COLOR_BUTTON (data);
+
+    priv = gsm_color_button_get_instance_private (color_button);
     GtkColorChooser *color_chooser;
 
     if (response == GTK_RESPONSE_OK) {
-        color_chooser = GTK_COLOR_CHOOSER (color_button->priv->cc_dialog);
+        color_chooser = GTK_COLOR_CHOOSER (priv->cc_dialog);
 
-        gtk_color_chooser_get_rgba (color_chooser, &color_button->priv->color);
+        gtk_color_chooser_get_rgba (color_chooser, &priv->color);
 
-        gtk_widget_hide (color_button->priv->cc_dialog);
+        gtk_widget_hide (priv->cc_dialog);
 
-        gtk_widget_queue_draw (GTK_WIDGET (&color_button->widget));
+        gtk_widget_queue_draw (GTK_WIDGET(color_button));
 
         g_signal_emit (color_button, color_button_signals[COLOR_SET], 0);
 
@@ -689,15 +671,18 @@ dialog_response (GtkWidget * widget, GtkResponseType response, gpointer data)
         g_object_thaw_notify (G_OBJECT (color_button));
     }
     else  /* (response == GTK_RESPONSE_CANCEL) */
-        gtk_widget_hide (color_button->priv->cc_dialog);
+        gtk_widget_hide (priv->cc_dialog);
 }
 
 static gboolean
 dialog_destroy (GtkWidget * widget, gpointer data)
 {
+    GSMColorButtonPrivate *priv;
     GSMColorButton *color_button = GSM_COLOR_BUTTON (data);
 
-    color_button->priv->cc_dialog = NULL;
+    priv = gsm_color_button_get_instance_private (color_button);
+
+    priv->cc_dialog = NULL;
 
     return FALSE;
 }
@@ -705,10 +690,13 @@ dialog_destroy (GtkWidget * widget, gpointer data)
 static gint
 gsm_color_button_clicked (GtkWidget * widget, GdkEventButton * event)
 {
+    GSMColorButtonPrivate *priv;
     GSMColorButton *color_button = GSM_COLOR_BUTTON (widget);
 
+    priv = gsm_color_button_get_instance_private (color_button);
+
     /* if dialog already exists, make sure it's shown and raised */
-    if (!color_button->priv->cc_dialog)
+    if (!priv->cc_dialog)
     {
         /* Create the dialog and connects its buttons */
         GtkWidget *cc_dialog;
@@ -718,7 +706,7 @@ gsm_color_button_clicked (GtkWidget * widget, GdkEventButton * event)
         if (!gtk_widget_is_toplevel (parent))
             parent = NULL;
 
-        cc_dialog = gtk_color_chooser_dialog_new (color_button->priv->title, GTK_WINDOW (parent));
+        cc_dialog = gtk_color_chooser_dialog_new (priv->title, GTK_WINDOW (parent));
 
         gtk_window_set_modal (GTK_WINDOW (cc_dialog), TRUE);
 
@@ -728,13 +716,13 @@ gsm_color_button_clicked (GtkWidget * widget, GdkEventButton * event)
         g_signal_connect (cc_dialog, "destroy",
                           G_CALLBACK (dialog_destroy), color_button);
 
-        color_button->priv->cc_dialog = cc_dialog;
+        priv->cc_dialog = cc_dialog;
     }
 
-    gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (color_button->priv->cc_dialog),
-                                &color_button->priv->color);
+    gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (priv->cc_dialog),
+                                &priv->color);
 
-    gtk_window_present (GTK_WINDOW (color_button->priv->cc_dialog));
+    gtk_window_present (GTK_WINDOW (priv->cc_dialog));
 
     return 0;
 }
@@ -744,8 +732,10 @@ gsm_color_button_pressed (GtkWidget * widget, GdkEventButton * event)
 {
     if ( (event->type == GDK_BUTTON_PRESS) && (event->button == 1) )
     {
+	GSMColorButtonPrivate *priv;
         GSMColorButton *color_button = GSM_COLOR_BUTTON (widget);
-        color_button->priv->button_down = TRUE;
+	priv = gsm_color_button_get_instance_private (color_button);
+	priv->button_down = TRUE;
     }
   return 0;
 }
@@ -753,10 +743,13 @@ gsm_color_button_pressed (GtkWidget * widget, GdkEventButton * event)
 static gint
 gsm_color_button_released (GtkWidget * widget, GdkEventButton * event)
 {
+    GSMColorButtonPrivate *priv;
     GSMColorButton *color_button = GSM_COLOR_BUTTON (widget);
-    if (color_button->priv->button_down && color_button->priv->in_button)
+
+    priv = gsm_color_button_get_instance_private (color_button);
+    if (priv->button_down && priv->in_button)
         gsm_color_button_clicked (widget, event);
-    color_button->priv->button_down = FALSE;
+    priv->button_down = FALSE;
     return 0;
 }
 
@@ -764,9 +757,12 @@ gsm_color_button_released (GtkWidget * widget, GdkEventButton * event)
 static gboolean
 gsm_color_button_enter_notify (GtkWidget * widget, GdkEventCrossing * event)
 {
+    GSMColorButtonPrivate *priv;
     GSMColorButton *color_button = GSM_COLOR_BUTTON (widget);
-    color_button->priv->highlight = 1.0;
-    color_button->priv->in_button = TRUE;
+
+    priv = gsm_color_button_get_instance_private (color_button);
+    priv->highlight = 1.0;
+    priv->in_button = TRUE;
     gtk_widget_queue_draw(widget);
     return FALSE;
 }
@@ -775,8 +771,11 @@ static gboolean
 gsm_color_button_leave_notify (GtkWidget * widget, GdkEventCrossing * event)
 {
     GSMColorButton *color_button = GSM_COLOR_BUTTON (widget);
-    color_button->priv->highlight = 0;
-    color_button->priv->in_button = FALSE;
+    GSMColorButtonPrivate *priv;
+
+    priv = gsm_color_button_get_instance_private (color_button);
+    priv->highlight = 0;
+    priv->in_button = FALSE;
     gtk_widget_queue_draw(widget);
     return FALSE;
 }
@@ -784,19 +783,25 @@ gsm_color_button_leave_notify (GtkWidget * widget, GdkEventCrossing * event)
 guint
 gsm_color_button_get_cbtype (GSMColorButton * color_button)
 {
+    GSMColorButtonPrivate *priv;
     g_return_val_if_fail (GSM_IS_COLOR_BUTTON (color_button), 0);
 
-    return color_button->priv->type;
+    priv = gsm_color_button_get_instance_private (color_button);
+
+    return priv->type;
 }
 
 void
 gsm_color_button_set_cbtype (GSMColorButton * color_button, guint type)
 {
+    GSMColorButtonPrivate *priv;
     g_return_if_fail (GSM_IS_COLOR_BUTTON (color_button));
 
-    color_button->priv->type = type;
+    priv = gsm_color_button_get_instance_private (color_button);
 
-    gtk_widget_queue_draw (GTK_WIDGET (&color_button->widget));
+    priv->type = type;
+
+    gtk_widget_queue_draw (GTK_WIDGET(color_button));
 
     g_object_notify (G_OBJECT (color_button), "type");
 }
@@ -804,20 +809,26 @@ gsm_color_button_set_cbtype (GSMColorButton * color_button, guint type)
 gdouble
 gsm_color_button_get_fraction (GSMColorButton * color_button)
 {
+    GSMColorButtonPrivate *priv;
     g_return_val_if_fail (GSM_IS_COLOR_BUTTON (color_button), 0);
 
-    return color_button->priv->fraction;
+    priv = gsm_color_button_get_instance_private (color_button);
+
+    return priv->fraction;
 }
 
 void
 gsm_color_button_set_fraction (GSMColorButton * color_button,
                                gdouble fraction)
 {
+    GSMColorButtonPrivate *priv;
     g_return_if_fail (GSM_IS_COLOR_BUTTON (color_button));
 
-    color_button->priv->fraction = fraction;
+    priv = gsm_color_button_get_instance_private (color_button);
 
-    gtk_widget_queue_draw (GTK_WIDGET (&color_button->widget));
+    priv->fraction = fraction;
+
+    gtk_widget_queue_draw (GTK_WIDGET(color_button));
 
     g_object_notify (G_OBJECT (color_button), "fraction");
 }
@@ -825,27 +836,32 @@ gsm_color_button_set_fraction (GSMColorButton * color_button,
 void
 gsm_color_button_get_color (GSMColorButton * color_button, GdkRGBA * color)
 {
+    GSMColorButtonPrivate *priv;
     g_return_if_fail (GSM_IS_COLOR_BUTTON (color_button));
 
-    color->red = color_button->priv->color.red;
-    color->green = color_button->priv->color.green;
-    color->blue = color_button->priv->color.blue;
-    color->alpha = color_button->priv->color.alpha;
+    priv = gsm_color_button_get_instance_private (color_button);
+    color->red = priv->color.red;
+    color->green = priv->color.green;
+    color->blue = priv->color.blue;
+    color->alpha = priv->color.alpha;
 }
 
 void
 gsm_color_button_set_color (GSMColorButton * color_button,
                             const GdkRGBA * color)
 {
+    GSMColorButtonPrivate *priv;
     g_return_if_fail (GSM_IS_COLOR_BUTTON (color_button));
     g_return_if_fail (color != NULL);
 
-    color_button->priv->color.red = color->red;
-    color_button->priv->color.green = color->green;
-    color_button->priv->color.blue = color->blue;
-    color_button->priv->color.alpha = color->alpha;
+    priv = gsm_color_button_get_instance_private (color_button);
 
-    gtk_widget_queue_draw (GTK_WIDGET (&color_button->widget));    //->priv->draw_area);
+    priv->color.red = color->red;
+    priv->color.green = color->green;
+    priv->color.blue = color->blue;
+    priv->color.alpha = color->alpha;
+
+    gtk_widget_queue_draw (GTK_WIDGET (color_button));
 
     g_object_notify (G_OBJECT (color_button), "color");
 }
@@ -855,25 +871,30 @@ gsm_color_button_set_title (GSMColorButton * color_button,
                             const gchar * title)
 {
     gchar *old_title;
+    GSMColorButtonPrivate *priv;
 
     g_return_if_fail (GSM_IS_COLOR_BUTTON (color_button));
+    priv = gsm_color_button_get_instance_private (color_button);
 
-    old_title = color_button->priv->title;
-    color_button->priv->title = g_strdup (title);
+    old_title = priv->title;
+    priv->title = g_strdup (title);
     g_free (old_title);
 
-    if (color_button->priv->cc_dialog)
-        gtk_window_set_title (GTK_WINDOW (color_button->priv->cc_dialog),
-                              color_button->priv->title);
+    if (priv->cc_dialog)
+        gtk_window_set_title (GTK_WINDOW (priv->cc_dialog),
+                              priv->title);
 
     g_object_notify (G_OBJECT (color_button), "title");
 }
 
 const gchar* gsm_color_button_get_title(GSMColorButton* color_button)
 {
+    GSMColorButtonPrivate *priv;
     g_return_val_if_fail(GSM_IS_COLOR_BUTTON(color_button), NULL);
 
-    return color_button->priv->title;
+    priv = gsm_color_button_get_instance_private (color_button);
+
+    return priv->title;
 }
 
 static void

--- a/src/gsm_color_button.h
+++ b/src/gsm_color_button.h
@@ -27,29 +27,14 @@
 #include <gtk/gtk.h>
 
 G_BEGIN_DECLS
+
 /* The GtkColorSelectionButton widget is a simple color picker in a button.
  * The button displays a sample of the currently selected color. When
  * the user clicks on the button, a color selection dialog pops up.
  * The color picker emits the "color_set" signal when the color is set.
  */
 #define GSM_TYPE_COLOR_BUTTON            (gsm_color_button_get_type ())
-#define GSM_COLOR_BUTTON(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), GSM_TYPE_COLOR_BUTTON, GSMColorButton))
-#define GSM_COLOR_BUTTON_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), GSM_TYPE_COLOR_BUTTON, GSMColorButtonClass))
-#define GSM_IS_COLOR_BUTTON(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GSM_TYPE_COLOR_BUTTON))
-#define GSM_IS_COLOR_BUTTON_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), GSM_TYPE_COLOR_BUTTON))
-#define GSM_COLOR_BUTTON_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), GSM_TYPE_COLOR_BUTTON, GSMColorButtonClass))
-typedef struct _GSMColorButton           GSMColorButton;
-typedef struct _GSMColorButtonClass      GSMColorButtonClass;
-typedef struct _GSMColorButtonPrivate    GSMColorButtonPrivate;
-
-struct _GSMColorButton
-{
-    GtkDrawingArea widget;
-
-    /*< private > */
-
-    GSMColorButtonPrivate *priv;
-};
+G_DECLARE_DERIVABLE_TYPE (GSMColorButton, gsm_color_button, GSM, COLOR_BUTTON, GtkDrawingArea)
 
 /* Widget types */
 enum
@@ -74,7 +59,6 @@ struct _GSMColorButtonClass
     void (*_gtk_reserved4) (void);
 };
 
-GType gsm_color_button_get_type (void) G_GNUC_CONST;
 GtkWidget *gsm_color_button_new (const GdkRGBA * color, guint type);
 void gsm_color_button_set_color (GSMColorButton * color_button, const GdkRGBA * color);
 void gsm_color_button_set_fraction (GSMColorButton * color_button, const gdouble fraction);


### PR DESCRIPTION
Fixes the issue with GLib >= 2.58, list of modified files:
- src/gsm_color_button.c
- src/gsm_color_button.h