### PR TITLE
Ensure proper translation of the about dialog title

### DIFF
--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -201,6 +201,7 @@ cb_about (GtkAction *action, gpointer data)
     gtk_show_about_dialog (
         GTK_WINDOW (procdata->app),
         "name",               _("System Monitor"),
+        "title",              _("About System Monitor"),
         "comments",           _("View current processes and monitor system state"),
         "version",            VERSION,
         "copyright",          _("Copyright \xc2\xa9 2001-2004 Kevin Vandersloot\n"


### PR DESCRIPTION
Note that GTK+ sets a default title of _("About %s") on the dialog
window (where %s is replaced by the name of the application, but
in order to ensure proper translation of the title, applications
should set the title property explicitly when constructing a
GtkAboutDialog

https://developer.gnome.org/gtk3/stable/GtkAboutDialog.html