### PR TITLE
gtk3: use “program-name” property in gtk_show_about_dialog

### DIFF
--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -200,10 +200,10 @@ cb_about (GtkAction *action, gpointer data)
 
     gtk_show_about_dialog (
         GTK_WINDOW (procdata->app),
-        "name",               _("System Monitor"),
+        "program-name",       _("System Monitor"),
+        "version",            VERSION,
         "title",              _("About System Monitor"),
         "comments",           _("View current processes and monitor system state"),
-        "version",            VERSION,
         "copyright",          _("Copyright \xc2\xa9 2001-2004 Kevin Vandersloot\n"
                                 "Copyright \xc2\xa9 2005-2007 Benoît Dejean\n"
                                 "Copyright \xc2\xa9 2011-2019 MATE developers"),


### PR DESCRIPTION
It also fixes the properties order to show properly the window title localized (l10n).

https://developer.gnome.org/gtk3/stable/GtkAboutDialog.html#GtkAboutDialog--program-name