### PR TITLE
Show 32/64-bit Version intead of release for Arch Linux in System tab

### DIFF
--- a/src/sysinfo.cpp
+++ b/src/sysinfo.cpp
@@ -72,16 +72,26 @@ namespace {
                         ("<big><big><b>" + this->distro_name + "</b></big></big>").c_str(),
                         NULL);
 
-
-            /* Translators: The first string parameter is release version (codename),
-             * the second one is the architecture, 32 or 64-bit */
+            char* markup;
 #ifdef __linux__
-            char* markup = g_strdup_printf(_("Release %s %s"),
-                                           this->distro_release.c_str(),
-                                           this->get_os_type().c_str());
+            if (this->distro_release != "")
+            {
+                /* Translators: The first string parameter is release version (codename),
+                 * the second one is the architecture, 32 or 64-bit */
+                markup = g_strdup_printf(_("Release %s %s"),
+                                         this->distro_release.c_str(),
+                                         this->get_os_type().c_str());
+            }
+            else
+            {
+                /* Translators: The string parameter is the architecture, 32 or 64-bit */
+                markup = g_strdup_printf(_("%s Version"),
+                                         this->get_os_type().c_str());
+            }
 #else
-            char* markup = g_strdup_printf(_("Release %s"),
-                                           this->distro_release.c_str());
+            /* Translators: The string parameter is release version (codename) */
+            markup = g_strdup_printf(_("Release %s"),
+                                     this->distro_release.c_str());
 #endif
 
             g_object_set(G_OBJECT(release),


### PR DESCRIPTION
Arch Linux is a rolling release distribution.

Test:
  - Backup /etc/os-release file
  - Replace the content of /etc/os-release file
  - Launch mate-system-monitor
  - Select System tab
  - Close mate-system-monitor
  - Restore /etc/os-release file

```shell
$ cat ~/os-release
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="0;36"
HOME_URL="https://www.archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://bugs.archlinux.org/"
```
After:

![Arch info](https://user-images.githubusercontent.com/10171411/56076368-953e9c80-5dd0-11e9-887b-54dcdf774a20.png)

Arch Linux Real Screenshot (makepkg/pacman -U):

![Arch](https://user-images.githubusercontent.com/10171411/56077320-04b98980-5ddb-11e9-98d8-e95d0ae8b27c.png)
