### PR TITLE
Show available disk space in ZFS

### DIFF
--- a/src/sysinfo.cpp
+++ b/src/sysinfo.cpp
@@ -269,6 +269,14 @@ namespace {
             this->free_space_bytes = 0;
 
             for (guint i = 0; i != mountlist.number; ++i) {
+                if ((string(entries[i].mountdir).compare("/") == 0) && \
+                    (string(entries[i].type).compare("zfs") == 0)) {
+                    // Root filesystem is ZFS based: Calculate usage based on "/".
+                    glibtop_fsusage usage;
+                    glibtop_get_fsusage(&usage, "/");
+                    this->free_space_bytes = usage.bavail * usage.block_size;
+                    break;
+                }
 
                 if (string(entries[i].devname).find("/dev/") != 0)
                     continue;


### PR DESCRIPTION
Applied patch:
https://github.com/OpenIndiana/oi-userland/blob/oi/hipster/components/desktop/mate/mate-system-monitor/patches/01-zfs.patch

Fixes #120

OpenIndiana Before:

![openindiana-after](https://user-images.githubusercontent.com/10171411/54545412-ead68380-49a1-11e9-9884-92505a2ad4ea.png)

OpenIndiana After:

![Captura de pantalla a 2019-04-13 15-58-45](https://user-images.githubusercontent.com/10171411/56080784-b1106580-5e05-11e9-87d7-771c44dda62b.png)

![Captura de pantalla a 2019-04-13 16-00-18](https://user-images.githubusercontent.com/10171411/56080787-b66db000-5e05-11e9-8910-2ede95bf2c4d.png)

FreeBSD Before:

![freebsd-after-2](https://user-images.githubusercontent.com/10171411/54529623-af778d00-4980-11e9-8448-634542b9e003.png)

FreeBSD After:

![Screenshot at 2019-04-13 17-11-51](https://user-images.githubusercontent.com/10171411/56081606-685daa00-5e0f-11e9-8b9b-7091d284d3c3.png)

![Screenshot at 2019-04-13 17-15-42](https://user-images.githubusercontent.com/10171411/56081637-d7d39980-5e0f-11e9-8386-4ce1e12e0fd3.png)

Ubuntu Before:

![Captura de pantalla a 2019-04-13 23-42-42](https://user-images.githubusercontent.com/10171411/56085582-04a2a380-5e46-11e9-9c26-dffeae32a911.png)

Ubuntu After:

![Captura de pantalla a 2019-04-13 23-24-58](https://user-images.githubusercontent.com/10171411/56085503-acb76d00-5e44-11e9-9b2d-03af6161579d.png)

![Captura de pantalla a 2019-04-14 13-03-09](https://user-images.githubusercontent.com/10171411/56092100-dcec2380-5eb7-11e9-87bd-f34fabd5a635.png)
