### PR TITLE
sysinfo: show debian version

### DIFF
--- a/src/sysinfo.cpp
+++ b/src/sysinfo.cpp
@@ -612,6 +612,14 @@ namespace {
                         this->distro_release = s.substr(start + 1, s.size() - start - 2);
                     }
                 }
+                input.close();
+                input.clear();
+            }
+            if (this->distro_release.empty()) {
+                input.open("/etc/debian_version");
+                if (input) {
+                    getline(input, this->distro_release);
+                }
             }
         }
     };


### PR DESCRIPTION
@rbuj thanks! ( https://github.com/mate-desktop/mate-system-monitor/pull/140#issuecomment-473723361 )

before:

![2019-04-16_00-55](https://user-images.githubusercontent.com/7734191/56170918-a3b0d200-5fe3-11e9-80b7-3525f96b502e.png)

later:

![2019-04-16_01-03](https://user-images.githubusercontent.com/7734191/56170927-a8758600-5fe3-11e9-856f-1ffc4ca67b8a.png)