### PR TITLE
Show GPU info on the System tab

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,8 @@ AM_CPPFLAGS = \
 	-DPROCMAN_DATADIR=\""$(datadir)/procman/"\" \
 	-DMATELOCALEDIR=\""$(datadir)/locale"\" \
 	-DDATADIR=\""$(datadir)"\" \
-	-DLIBEXEC_DIR=\""$(pkglibexecdir)"\" \
+	-DPKGLIBEXECDIR=\""$(pkglibexecdir)"\" \
+	-DLIBEXECDIR=\""$(libexecdir)"\" \
 	@PROCMAN_CFLAGS@ \
 	@SYSTEMD_CFLAGS@
 

--- a/src/procman_pkexec.cpp
+++ b/src/procman_pkexec.cpp
@@ -10,7 +10,7 @@ procman_pkexec_create_root_password_dialog (const char *command)
     GError *error = NULL;
 
     command_line = g_strdup_printf ("pkexec --disable-internal-agent %s/msm-%s",
-                                    LIBEXEC_DIR, command);
+                                    PKGLIBEXECDIR, command);
     success = g_spawn_command_line_sync (command_line, NULL, NULL, NULL, &error);
     g_free (command_line);
 


### PR DESCRIPTION
based on https://gitlab.gnome.org/GNOME/gnome-control-center/blob/master/panels/info/cc-info-overview-panel.c

Close #150

Screenshot (gnome-session):

![GPIU info](https://user-images.githubusercontent.com/10171411/56273019-36449480-60fc-11e9-9383-635fe12687c6.png)

Edit:
Change "GPU:" label to "Graphics:"

Screenshot (mate session):
Requires mate-desktop/mate-session-manager#203

![Captura de pantalla a 2019-04-18 02-29-48](https://user-images.githubusercontent.com/10171411/56329041-faeca900-6181-11e9-8061-a7442531b183.png)
