### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.63])
 
 AC_INIT([mate-system-monitor],
 	[1.23.0],
-        [http://www.mate-desktop.org/])
+        [https://mate-desktop.org/])
 AC_CONFIG_SRCDIR(configure.ac)
 AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_MACRO_DIR([m4])

--- a/mate-system-monitor.appdata.xml.in
+++ b/mate-system-monitor.appdata.xml.in
@@ -35,7 +35,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">http://www.mate-desktop.org</url>
+ <url type="homepage">https://mate-desktop.org</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>

--- a/org.mate.mate-system-monitor.policy.in.in
+++ b/org.mate.mate-system-monitor.policy.in.in
@@ -4,7 +4,7 @@
  "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
 <policyconfig>
   <vendor>MATE Desktop</vendor>
-  <vendor_url>http://www.mate-desktop.org/</vendor_url>
+  <vendor_url>https://mate-desktop.org/</vendor_url>
   <icon_name>utilities-system-monitor</icon_name>
 
   <action id="org.mate.mate-system-monitor.kill">

--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -214,7 +214,7 @@ cb_about (GtkAction *action, gpointer data)
         "translator-credits", _("translator-credits"),
         "license",            license_trans,
         "wrap-license",       TRUE,
-        "website",            "http://www.mate-desktop.org",
+        "website",            "https://mate-desktop.org",
         NULL
         );
 


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.