### PR TITLE
Use MATE_COMPILE_WARNINGS and MATE_CXX_WARNINGS macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -170,6 +170,17 @@ before_scripts:
   -     curl -Ls -o debian.sh https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/debian.sh
   -     bash ./debian.sh
   - fi
+  - cd ${START_DIR}
+  - '[ -f mate-common-1.23.3.tar.xz ] || curl -Ls -o mate-common-1.23.3.tar.xz http://pub.mate-desktop.org/releases/1.23/mate-common-1.23.3.tar.xz'
+  - tar xf mate-common-1.23.3.tar.xz
+  - cd mate-common-1.23.3
+  - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
+  -     ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --libexecdir=/usr/lib/x86_64-linux-gnu
+  - else
+  -     ./configure --prefix=/usr
+  - fi
+  - make
+  - make install
 
 build_scripts:
   - ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ env:
 requires:
   archlinux:
     # Useful URL: https://git.archlinux.org/svntogit/community.git/tree/mate-system-monitor
+    - autoconf-archive
     - clang
     - gcc
     - git
@@ -80,6 +81,7 @@ requires:
   debian:
     # Useful URL: https://github.com/mate-desktop/debian-packages
     # Useful URL: https://salsa.debian.org/debian-mate-team/mate-system-monitor
+    - autoconf-archive
     - clang
     - clang-tools
     - cppcheck
@@ -103,6 +105,7 @@ requires:
 
   fedora:
     # Useful URL: https://src.fedoraproject.org/cgit/rpms/mate-system-monitor.git
+    - autoconf-archive
     - clang
     - clang-analyzer
     - cppcheck-htmlreport
@@ -123,6 +126,7 @@ requires:
     - systemd-devel
 
   ubuntu:
+    - autoconf-archive
     - clang
     - clang-tools
     - g++

--- a/configure.ac
+++ b/configure.ac
@@ -60,27 +60,8 @@ fi
 AM_CONDITIONAL(HAVE_SYSTEMD, [test "$have_systemd" = "yes"])
 
 # Compiler warnings
-MATE_COMPILE_WARNINGS([maximum])
-
-AC_ARG_ENABLE(more-warnings,
-[AC_HELP_STRING([--enable-more-warnings],[Maximum compiler warnings])],
-set_more_warnings="$enableval",[
-    set_more_warnings=yes
-])
-AC_MSG_CHECKING(for more warnings, including -Werror)
-if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
-    AC_MSG_RESULT(yes)
-    CFLAGS="\
-    -Wall \
-    -Winline \
-    -Wchar-subscripts -Wmissing-declarations -Wmissing-prototypes \
-    -Wnested-externs -Wpointer-arith \
-    -Wcast-align -Wsign-compare \
-    $CFLAGS"
-    CXXFLAGS="-Wall $CXXFLAGS"
-else
-    AC_MSG_RESULT(no)
-fi
+MATE_COMPILE_WARNINGS([yes])
+MATE_CXX_WARNINGS([yes])
 
 dnl CXXFLAGS="-fvisibility=hidden -fvisibility-inlines-hidden $CXXFLAGS"
 dnl CXXFLAGS="-fvisibility-inlines-hidden $CXXFLAGS"
@@ -117,9 +98,11 @@ Configuration:
 
         Source code location:   ${srcdir}
         C Compiler:             ${CC}
-        C++ Compiler:           ${CXX}
         CFLAGS:                 ${CFLAGS}
+        WARN_CFLAGS:            ${WARN_CFLAGS}
+        C++ Compiler:           ${CXX}
         CXXFLAGS:               ${CXXFLAGS}
+        WARN_CXXFLAGS:          ${WARN_CXXFLAGS}
         Maintainer mode:        ${USE_MAINTAINER_MODE}
         Systemd support:        ${have_systemd}
 "

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,6 +50,12 @@ mate_system_monitor_SOURCES = \
 	$(mate_system_monitor_cpp_files) \
 	$(mate_system_monitor_c_files)
 
+mate_system_monitor_CXXFLAGS = \
+	$(WARN_CXXFLAGS)
+
+mate_system_monitor_CFLAGS = \
+	$(WARN_CFLAGS)
+
 mate_system_monitor_LDADD = @PROCMAN_LIBS@ @SYSTEMD_LIBS@ libbacon.la
 
 
@@ -57,7 +63,8 @@ noinst_LTLIBRARIES = libbacon.la
 libbacon_la_SOURCES = \
 	bacon-message-connection.c \
 	bacon-message-connection.h
-
+libbacon_la_CFLAGS = \
+	$(WARN_CFLAGS)
 
 specdir = $(datadir)/procman
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -4,9 +4,9 @@ AM_CPPFLAGS = $(TOOLS_CFLAGS)
 
 msm_renice_SOURCES = msm_execute_helper.c
 msm_renice_LDADD = $(TOOLS_LIBS)
-msm_renice_CFLAGS = -DCOMMAND=\"renice\"
+msm_renice_CFLAGS = -DCOMMAND=\"renice\" $(WARN_CFLAGS)
 
 msm_kill_SOURCES = msm_execute_helper.c
 msm_kill_LDADD = $(TOOLS_LIBS)
-msm_kill_CFLAGS = -DCOMMAND=\"kill\"
+msm_kill_CFLAGS = -DCOMMAND=\"kill\" $(WARN_CFLAGS)
 


### PR DESCRIPTION
- It adds WARN_CFLAGS to CFLAGS, and WARN_CXXLAGS to CXXFLAGS
- By default, --enable-cxx-warnings=yes --enable-compile-warnings=yes
- It prints the warning flags in configure summary

Tests:
```
$ ./autogen.sh --enable-cxx-warnings=no --enable-compile-warnings=no
$ ./autogen.sh --enable-cxx-warnings=no --enable-compile-warnings=yes
$ ./autogen.sh --enable-cxx-warnings=yes --enable-compile-warnings=no
$ ./autogen.sh --enable-cxx-warnings=yes --enable-compile-warnings=yes
```
```
$ make clean && make AM_DEFAULT_VERBOSITY=1
```
It requires https://github.com/mate-desktop/mate-common/pull/30