### PR TITLE
pretty-table: prefer GIO to get application icons

### DIFF
--- a/src/iconthemewrapper.cpp
+++ b/src/iconthemewrapper.cpp
@@ -27,3 +27,31 @@ procman::IconThemeWrapper::load_icon(const Glib::ustring& icon_name, int size) c
     }
 }
 
+Glib::RefPtr<Gdk::Pixbuf>
+procman::IconThemeWrapper::load_gicon(const Glib::RefPtr<Gio::Icon>& gicon,
+                                      int size, Gtk::IconLookupFlags flags) const
+{
+    Gtk::IconInfo icon_info;
+    gint scale = gdk_window_get_scale_factor (gdk_get_default_root_window ());
+    icon_info = Gtk::IconTheme::get_default()->lookup_icon(gicon, size, scale, flags);
+
+    if (!icon_info) {
+        return Glib::RefPtr<Gdk::Pixbuf>();
+    }
+
+    try
+    {
+        return icon_info.load_icon();
+    }
+    catch (Gtk::IconThemeError &error)
+    {
+        if (error.code() != Gtk::IconThemeError::ICON_THEME_NOT_FOUND)
+            g_error("Cannot load gicon from theme: %s", error.what().c_str());
+        return Glib::RefPtr<Gdk::Pixbuf>();
+    }
+    catch (Gio::Error &error)
+    {
+        g_debug("Could not load gicon: %s", error.what().c_str());
+        return Glib::RefPtr<Gdk::Pixbuf>();
+    }
+}

--- a/src/iconthemewrapper.h
+++ b/src/iconthemewrapper.h
@@ -14,6 +14,8 @@ namespace procman
         // returns 0 instead of raising an exception
         Glib::RefPtr<Gdk::Pixbuf>
             load_icon(const Glib::ustring& icon_name, int size) const;
+        Glib::RefPtr<Gdk::Pixbuf>
+            load_gicon(const Glib::RefPtr<Gio::Icon>& gicon, int size, Gtk::IconLookupFlags flags) const;
 
         const IconThemeWrapper* operator->() const
         { return this; }

--- a/src/prettytable.h
+++ b/src/prettytable.h
@@ -7,6 +7,7 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <glibmm/refptr.h>
 #include <gdkmm/pixbuf.h>
+#include <giomm/filemonitor.h>
 
 #include <map>
 #include <string>
@@ -43,18 +44,28 @@ private:
 
     Glib::RefPtr<Gdk::Pixbuf> get_icon_from_theme(const ProcInfo &);
     Glib::RefPtr<Gdk::Pixbuf> get_icon_from_default(const ProcInfo &);
+    Glib::RefPtr<Gdk::Pixbuf> get_icon_from_gio(const ProcInfo &);
     Glib::RefPtr<Gdk::Pixbuf> get_icon_from_wnck(const ProcInfo &);
     Glib::RefPtr<Gdk::Pixbuf> get_icon_from_name(const ProcInfo &);
     Glib::RefPtr<Gdk::Pixbuf> get_icon_for_kernel(const ProcInfo &);
     Glib::RefPtr<Gdk::Pixbuf> get_icon_dummy(const ProcInfo &);
 
     bool get_default_icon_name(const string &cmd, string &name);
+    void file_monitor_event (Glib::RefPtr<Gio::File>,
+                             Glib::RefPtr<Gio::File>,
+                             Gio::FileMonitorEvent);
+    void init_gio_app_cache ();
+
 
     typedef std::map<string, Glib::RefPtr<Gdk::Pixbuf> > IconCache;
     typedef std::map<pid_t, Glib::RefPtr<Gdk::Pixbuf> > IconsForPID;
+    typedef std::map<string, Glib::RefPtr<Gio::AppInfo> > AppCache;
+    typedef std::map<string, Glib::RefPtr<Gio::FileMonitor> > DesktopDirMonitors;
 
     IconsForPID apps;
     IconCache defaults;
+    DesktopDirMonitors monitors;
+    AppCache gio_apps;
     procman::IconThemeWrapper theme;
 };
 


### PR DESCRIPTION
based on https://github.com/GNOME/gnome-system-monitor/commit/97fb0b3e3b27b0a26488df5e4e2612ce79f81d53

### before
![Screenshot at 2020-07-25 14-12-50](https://user-images.githubusercontent.com/10171411/88456865-b6ba7f00-ce81-11ea-926f-d960ff126d99.png)

### after
![Screenshot at 2020-07-25 14-10-56](https://user-images.githubusercontent.com/10171411/88456863-b02c0780-ce81-11ea-97cd-dbb1810bc6ae.png)
