### PR TITLE
procdialogs: Remove trailing spaces

### DIFF
--- a/src/procdialogs.cpp
+++ b/src/procdialogs.cpp
@@ -93,7 +93,7 @@ procdialog_create_kill_dialog (ProcData *procdata, int signal)
             /*xgettext: primary alert message for ending multiple processes*/
             primary = g_strdup_printf (_("Are you sure you want to end the %d selected processes?"),
                                        selected_count);
-  
+
         }
     }
 


### PR DESCRIPTION
`find . \( -name '*.h' -o -name '*.cpp' \) -exec sed -i 's/[[:space:]]*$//' {} \;`