### PR TITLE
build: display package name and version in configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,8 +94,10 @@ mate-system-monitor.desktop.in
 AC_OUTPUT
 
 echo "
+Configure summary:
 
-Configuration:
+        ${PACKAGE_STRING}
+        `echo $PACKAGE_STRING | sed "s/./=/g"`
 
         Source code location:   ${srcdir}
         C Compiler:             ${CC}


### PR DESCRIPTION
```
$ ./autogen.sh --prefix=/usr
<cut>

Configure summary:

        mate-system-monitor 1.25.0
        ==========================

        Source code location:   .
        C Compiler:             gcc
        CFLAGS:                 
        WARN_CFLAGS:            -Wall -Wmissing-prototypes
        C++ Compiler:           g++
        CXXFLAGS:               
        WARN_CXXFLAGS:          -Wall -Woverloaded-virtual
        Maintainer mode:        yes
        Systemd support:        no

Now type `make' to compile mate-system-monitor
```