### PR TITLE
gsm_color_button: macro "__GSM_COLOR_BUTTON_C__" is not used

### DIFF
--- a/src/gsm_color_button.c
+++ b/src/gsm_color_button.c
@@ -950,5 +950,3 @@ gsm_color_button_get_property (GObject * object,
             break;
     }
 }
-
-#define __GSM_COLOR_BUTTON_C__


### PR DESCRIPTION
```
gsm_color_button.c:954: warning: macro "__GSM_COLOR_BUTTON_C__" is not used [-Wunused-macros]
  954 | #define __GSM_COLOR_BUTTON_C__
      |
```