### PR TITLE
smooth_refresh: comparison of unsigned expression in '< 0' is always false

### DIFF
--- a/src/smooth_refresh.cpp
+++ b/src/smooth_refresh.cpp
@@ -34,7 +34,7 @@ unsigned SmoothRefresh::get_own_cpu_usage()
         this->last_cpu_time = proctime.rtime;
     }
 
-    usage = CLAMP(usage, 0, 100);
+    usage = MIN (usage, 100);
 
     this->last_total_time = cpu.total;
 


### PR DESCRIPTION
```
smooth_refresh.cpp: In member function 'unsigned int SmoothRefresh::get_own_cpu_usage()':
/usr/include/glib-2.0/glib/gmacros.h:813:63: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
  813 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                           ~~~~^~~~~~~
smooth_refresh.cpp:37:13: note: in expansion of macro 'CLAMP'
   37 |     usage = CLAMP(usage, 0, 100);
      |             ^~~~~
```