### PR TITLE
openfiles: g_memdup is dreprecated from glib 2.68

### DIFF
--- a/src/openfiles.cpp
+++ b/src/openfiles.cpp
@@ -119,7 +119,11 @@ add_new_files (gpointer key, gpointer value, gpointer data)
                         COL_FD, openfiles->fd,
                         COL_TYPE, get_type_name(static_cast<glibtop_file_type>(openfiles->type)),
                         COL_OBJECT, object,
+#if GLIB_CHECK_VERSION (2, 68, 0)
+                        COL_OPENFILE_STRUCT, g_memdup2(openfiles, sizeof(*openfiles)),
+#else
                         COL_OPENFILE_STRUCT, g_memdup(openfiles, sizeof(*openfiles)),
+#endif
                         -1);
 
     g_free(object);


### PR DESCRIPTION
```
openfiles.cpp:122:84: warning: ‘void* g_memdup(gconstpointer, guint)’ is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
  122 |                         COL_OPENFILE_STRUCT, g_memdup(openfiles, sizeof(*openfiles)),
      |                                                                                    ^
In file included from /usr/include/glib-2.0/glib.h:82,
                 from /usr/include/glib-2.0/glib/gi18n.h:21,
                 from openfiles.cpp:3:
/usr/include/glib-2.0/glib/gstrfuncs.h:257:23: note: declared here
  257 | gpointer              g_memdup         (gconstpointer mem,
      |                       ^~~~~~~~
memmaps.cpp: In member function ‘std::string {anonymous}::InodeDevices::get(guint64)’:
```