### PR TITLE
add wayland support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,8 +42,24 @@ LIBXML_REQUIRED=2.0
 RSVG_REQUIRED=2.35
 SYSTEMD_REQUIRED=44
 
-PKG_CHECK_MODULES(GMODULE,gmodule-2.0,[GMODULE_ADD="gmodule-2.0"],[GMODULE_ADD=""])
-PKG_CHECK_MODULES(PROCMAN,$GMODULE_ADD glib-2.0 >= $GLIB_REQUIRED libgtop-2.0 >= $LIBGTOP_REQUIRED libwnck-3.0 >= $LIBWNCK_REQUIRED gtk+-3.0 >= $GTK_REQUIRED gtkmm-3.0 >= $GTKMM_REQUIRED libxml-2.0 >= $LIBXML_REQUIRED librsvg-2.0 >= $RSVG_REQUIRED glibmm-2.4 >= $GLIBMM_REQUIRED giomm-2.4 >= $GIOMM_REQUIRED)
+PKG_CHECK_MODULES(PROCMAN, [
+    glib-2.0 >= $GLIB_REQUIRED
+    libgtop-2.0 >= $LIBGTOP_REQUIRED
+    gtk+-3.0 >= $GTK_REQUIRED
+    gtkmm-3.0 >= $GTKMM_REQUIRED
+    libxml-2.0 >= $LIBXML_REQUIRED
+    librsvg-2.0 >= $RSVG_REQUIRED
+    glibmm-2.4 >= $GLIBMM_REQUIRED
+    giomm-2.4 >= $GIOMM_REQUIRED
+    gmodule-2.0
+])
+
+AC_ARG_ENABLE(wnck, AS_HELP_STRING([--enable-wnck], [enable wnck support]), enable_wnck="$enableval", enable_wnck=no)
+if test "x$enable_wnck" != "xno"; then
+        PKG_CHECK_MODULES(WNCK, libwnck-3.0 >= $LIBWNCK_REQUIRED gdk-x11-3.0)
+        AC_DEFINE(HAVE_WNCK, 1, [Define if libwnck is available])
+fi
+AM_CONDITIONAL(HAVE_WNCK, [test "enable_wnck" = "yes"])
 
 PKG_CHECK_MODULES(TOOLS, glib-2.0 >= $GLIB_REQUIRED)
 
@@ -128,4 +144,5 @@ Configure summary:
         WARN_CXXFLAGS:          ${WARN_CXXFLAGS}
         Maintainer mode:        ${USE_MAINTAINER_MODE}
         Systemd support:        ${have_systemd}
+        wnck support:           ${enable_wnck}
 "

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,8 @@ AM_CPPFLAGS = \
 	-DPKGLIBEXECDIR=\""$(pkglibexecdir)"\" \
 	-DLIBEXECDIR=\""$(libexecdir)"\" \
 	@PROCMAN_CFLAGS@ \
-	@SYSTEMD_CFLAGS@
+	@SYSTEMD_CFLAGS@ \
+	@WNCK_CFLAGS@
 
 bin_PROGRAMS = mate-system-monitor
 
@@ -60,7 +61,7 @@ mate_system_monitor_CXXFLAGS = \
 mate_system_monitor_CFLAGS = \
 	$(WARN_CFLAGS)
 
-mate_system_monitor_LDADD = @PROCMAN_LIBS@ @SYSTEMD_LIBS@
+mate_system_monitor_LDADD = @PROCMAN_LIBS@ @SYSTEMD_LIBS@ @WNCK_LIBS@
 
 specdir = $(datadir)/procman
 

--- a/src/prettytable.h
+++ b/src/prettytable.h
@@ -12,10 +12,12 @@
 #include <map>
 #include <string>
 
+#ifdef HAVE_WNCK
 extern "C" {
 #define WNCK_I_KNOW_THIS_IS_UNSTABLE
 #include <libwnck/libwnck.h>
 }
+#endif
 
 #include "iconthemewrapper.h"
 
@@ -35,17 +37,20 @@ class PrettyTable
 
 private:
 
+#ifdef HAVE_WNCK
     static void on_application_opened(WnckScreen* screen, WnckApplication* app, gpointer data);
     static void on_application_closed(WnckScreen* screen, WnckApplication* app, gpointer data);
 
     void register_application(pid_t pid, Glib::RefPtr<Gdk::Pixbuf> icon);
     void unregister_application(pid_t pid);
-
+#endif
 
     Glib::RefPtr<Gdk::Pixbuf> get_icon_from_theme(const ProcInfo &);
     Glib::RefPtr<Gdk::Pixbuf> get_icon_from_default(const ProcInfo &);
     Glib::RefPtr<Gdk::Pixbuf> get_icon_from_gio(const ProcInfo &);
+#ifdef HAVE_WNCK
     Glib::RefPtr<Gdk::Pixbuf> get_icon_from_wnck(const ProcInfo &);
+#endif
     Glib::RefPtr<Gdk::Pixbuf> get_icon_from_name(const ProcInfo &);
     Glib::RefPtr<Gdk::Pixbuf> get_icon_for_kernel(const ProcInfo &);
     Glib::RefPtr<Gdk::Pixbuf> get_icon_dummy(const ProcInfo &);

--- a/src/procman-app.cpp
+++ b/src/procman-app.cpp
@@ -207,7 +207,6 @@ procman_data_new (GSettings *settings)
     ProcData *pd;
     gchar *color;
     gchar **keys;
-    gint swidth, sheight;
     glibtop_cpu cpu;
 
     pd = ProcData::get_instance();
@@ -308,10 +307,19 @@ procman_data_new (GSettings *settings)
     g_free (color);
 
     /* Sanity checks */
-    swidth = WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ()));
-    sheight = HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ()));
-    pd->config.width = CLAMP (pd->config.width, 50, swidth);
-    pd->config.height = CLAMP (pd->config.height, 50, sheight);
+    GdkDisplay *display;
+    GdkMonitor *monitor;
+    GdkRectangle monitor_geometry;
+
+    display = gdk_display_get_default ();
+    monitor = gdk_display_get_monitor_at_point (display, pd->config.xpos, pd->config.ypos);
+    if (monitor == NULL) {
+        monitor = gdk_display_get_monitor (display, 0);
+    }
+    gdk_monitor_get_geometry (monitor, &monitor_geometry);
+
+    pd->config.width = CLAMP (pd->config.width, 50, monitor_geometry.width);
+    pd->config.height = CLAMP (pd->config.height, 50, monitor_geometry.height);
     pd->config.update_interval = MAX (pd->config.update_interval, 1000);
     pd->config.graph_update_interval = MAX (pd->config.graph_update_interval, 250);
     pd->config.disks_update_interval = MAX (pd->config.disks_update_interval, 1000);

--- a/src/procman.h
+++ b/src/procman.h
@@ -126,8 +126,10 @@ MutableProcInfo()
     gulong memwritable;
     gulong mem;
 
+#ifdef HAVE_WNCK
     // wnck gives an unsigned long
     gulong memxserver;
+#endif
 
     gulong start_time;
     guint64 cpu_time;


### PR DESCRIPTION
therefore make libwnck optional (libwnck is x11 only)

see https://gitlab.gnome.org/GNOME/gnome-system-monitor/-/commit/3705931e307e87878f205b905eaa3f5daaffcf09
and https://gitlab.gnome.org/GNOME/gnome-system-monitor/-/commit/8c4d47d625661e848643ce564f63ed3ec1e83293
and https://gitlab.gnome.org/GNOME/gnome-system-monitor/-/commit/1ea64e9965bd6f1026f1167b692e7cc83c269be3

To enable libwnck support you need to compile with the `--enable-wnck` flag.