### PR TITLE
reduce the usage of gtkmm

### DIFF
--- a/src/iconthemewrapper.cpp
+++ b/src/iconthemewrapper.cpp
@@ -1,7 +1,6 @@
 #include <config.h>
 
-#include <gtkmm/icontheme.h>
-#include <giomm/error.h>
+#include <gtk/gtk.h>
 
 #include "iconthemewrapper.h"
 
@@ -10,48 +9,47 @@ Glib::RefPtr<Gdk::Pixbuf>
 procman::IconThemeWrapper::load_icon(const Glib::ustring& icon_name, int size) const
 {
     gint scale = gdk_window_get_scale_factor (gdk_get_default_root_window ());
-    try
-    {
-      return Gtk::IconTheme::get_default()->load_icon(icon_name, size, scale, Gtk::ICON_LOOKUP_USE_BUILTIN | Gtk::ICON_LOOKUP_FORCE_SIZE);
-    }
-    catch (Gtk::IconThemeError &error)
-    {
-        if (error.code() != Gtk::IconThemeError::ICON_THEME_NOT_FOUND)
-            g_error("Cannot load icon '%s' from theme: %s", icon_name.c_str(), error.what().c_str());
+    GError * error = NULL;
+    GdkPixbuf * icon = gtk_icon_theme_load_icon_for_scale (gtk_icon_theme_get_default (), icon_name.c_str(), size, scale, static_cast<GtkIconLookupFlags>(GTK_ICON_LOOKUP_USE_BUILTIN | GTK_ICON_LOOKUP_FORCE_SIZE), &error);
+    if (error != NULL) {
+        if (error->domain == GTK_ICON_THEME_ERROR) {
+            if (error->code != GTK_ICON_THEME_NOT_FOUND)
+                g_error("Cannot load icon '%s' from theme: %s", icon_name.c_str(), error->message);
+        }
+        else {
+            g_debug("Could not load icon '%s' : %s", icon_name.c_str(), error->message);
+        }
+        g_error_free (error);
         return Glib::RefPtr<Gdk::Pixbuf>();
     }
-    catch (Gio::Error &error)
-    {
-        g_debug("Could not load icon '%s' : %s", icon_name.c_str(), error.what().c_str());
-        return Glib::RefPtr<Gdk::Pixbuf>();
-    }
+    return Glib::wrap(icon);
 }
 
 Glib::RefPtr<Gdk::Pixbuf>
 procman::IconThemeWrapper::load_gicon(const Glib::RefPtr<Gio::Icon>& gicon,
-                                      int size, Gtk::IconLookupFlags flags) const
+                                      int size, GtkIconLookupFlags flags) const
 {
-    Gtk::IconInfo icon_info;
     gint scale = gdk_window_get_scale_factor (gdk_get_default_root_window ());
-    icon_info = Gtk::IconTheme::get_default()->lookup_icon(gicon, size, scale, flags);
+    GtkIconInfo * icon_info = gtk_icon_theme_lookup_by_gicon_for_scale (gtk_icon_theme_get_default (), gicon->gobj(), size, scale, flags);
 
-    if (!icon_info) {
+    if (icon_info == NULL) {
         return Glib::RefPtr<Gdk::Pixbuf>();
     }
 
-    try
-    {
-        return icon_info.load_icon();
-    }
-    catch (Gtk::IconThemeError &error)
-    {
-        if (error.code() != Gtk::IconThemeError::ICON_THEME_NOT_FOUND)
-            g_error("Cannot load gicon from theme: %s", error.what().c_str());
+    GError * error = NULL;
+    GdkPixbuf * icon = gtk_icon_info_load_icon (icon_info, &error);
+    if (error != NULL) {
+        if (error->domain == GTK_ICON_THEME_ERROR) {
+            if (error->code != GTK_ICON_THEME_NOT_FOUND)
+                g_error("Cannot load gicon from theme: %s", error->message);
+        }
+        else {
+            g_debug("Could not load gicon: %s", error->message);
+        }
+        g_object_unref (icon_info);
+        g_error_free (error);
         return Glib::RefPtr<Gdk::Pixbuf>();
     }
-    catch (Gio::Error &error)
-    {
-        g_debug("Could not load gicon: %s", error.what().c_str());
-        return Glib::RefPtr<Gdk::Pixbuf>();
-    }
+    g_object_unref (icon_info);
+    return Glib::wrap(icon);
 }

--- a/src/iconthemewrapper.h
+++ b/src/iconthemewrapper.h
@@ -1,9 +1,9 @@
 #ifndef H_PROCMAN_ICONTHEMEWRAPPER_H_1185707711
 #define H_PROCMAN_ICONTHEMEWRAPPER_H_1185707711
 
+#include <gtk/gtk.h>
 #include <glibmm/refptr.h>
 #include <glibmm/ustring.h>
-#include <gtkmm/icontheme.h>
 #include <gdkmm/pixbuf.h>
 
 namespace procman
@@ -15,7 +15,7 @@ namespace procman
         Glib::RefPtr<Gdk::Pixbuf>
             load_icon(const Glib::ustring& icon_name, int size) const;
         Glib::RefPtr<Gdk::Pixbuf>
-            load_gicon(const Glib::RefPtr<Gio::Icon>& gicon, int size, Gtk::IconLookupFlags flags) const;
+            load_gicon(const Glib::RefPtr<Gio::Icon>& gicon, int size, GtkIconLookupFlags flags) const;
 
         const IconThemeWrapper* operator->() const
         { return this; }

--- a/src/lsof.cpp
+++ b/src/lsof.cpp
@@ -1,6 +1,5 @@
 #include <config.h>
 
-#include <gtkmm/messagedialog.h>
 #include <glibmm/regex.h>
 #include <glib/gi18n.h>
 #include <glibtop/procopenfiles.h>
@@ -123,15 +122,11 @@ namespace
                                           _("Error"),
                                           _("'%s' is not a valid Perl regular expression."),
                                           "%s");
-            std::string message = make_string(g_strdup_printf(msg, this->pattern().c_str(), error.what().c_str()));
-            g_free(msg);
 
-            Gtk::MessageDialog dialog(message,
-                                      true, // use markup
-                                      Gtk::MESSAGE_ERROR,
-                                      Gtk::BUTTONS_OK,
-                                      true); // modal
-            dialog.run();
+            GtkWidget * dialog = gtk_message_dialog_new_with_markup (NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_OK, msg, this->pattern().c_str(), error.what().c_str());
+            gtk_dialog_run (GTK_DIALOG(dialog));
+            gtk_widget_destroy (dialog);
+            g_free (msg);
         }
 
 

--- a/src/prettytable.cpp
+++ b/src/prettytable.cpp
@@ -219,7 +219,7 @@ PrettyTable::get_icon_from_gio(const ProcInfo &info)
           gicon = app->get_icon();
 
         if (gicon)
-          icon = this->theme->load_gicon(gicon, APP_ICON_SIZE, Gtk::ICON_LOOKUP_USE_BUILTIN | Gtk::ICON_LOOKUP_FORCE_SIZE);
+          icon = this->theme->load_gicon(gicon, APP_ICON_SIZE, static_cast<GtkIconLookupFlags>(GTK_ICON_LOOKUP_USE_BUILTIN | GTK_ICON_LOOKUP_FORCE_SIZE));
     }
 
     g_strfreev(cmdline);

--- a/src/prettytable.h
+++ b/src/prettytable.h
@@ -8,6 +8,7 @@
 #include <glibmm/refptr.h>
 #include <gdkmm/pixbuf.h>
 #include <giomm/filemonitor.h>
+#include <giomm/appinfo.h>
 
 #include <map>
 #include <string>


### PR DESCRIPTION
Since mate-system-monitor is the only mate component written in C++ I thought it might be worthwhile to reduce the usage of gtkmm and C++ in order to make it more consistent with the rest of the components and therefore more maintainable. Most of the codebase already uses the C API of GTK directly and only a small part uses gtkmm.

I might put some more effort into this since it is a good learning exercise for me but please tell me if you are against this direction since I don't want to waste any time here.