### PR TITLE
Allow to change the number of columns in the CPU History graph

### DIFF
--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -323,7 +323,9 @@ create_sys_view (ProcData *procdata)
         temp_hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
         gtk_widget_set_hexpand (temp_hbox, TRUE);
         gtk_grid_attach(GTK_GRID(cpu_grid), temp_hbox,
-                        i % 4, i / 4, 1, 1);
+                        i % procdata->config.num_cpu_columns,
+                        i / procdata->config.num_cpu_columns,
+                        1, 1);
 
         color_picker = gsm_color_button_new (&cpu_graph->colors.at(i), GSMCP_TYPE_CPU);
         g_signal_connect (G_OBJECT (color_picker), "color_set",

--- a/src/org.mate.system-monitor.gschema.xml.in
+++ b/src/org.mate.system-monitor.gschema.xml.in
@@ -52,6 +52,11 @@
       <summary>Saves the currently viewed tab</summary>
       <description>0 for the System Info, 1 for the processes list, 2 for the resources and 3 for the disks list</description>
     </key>
+    <key name="num-cpu-columns" type="i">
+      <range min="3" max="12"/>
+      <default>4</default>
+      <summary>Number of columns in CPU History graph</summary>
+    </key>
     <key name="cpu-color0" type="s">
       <default>'#FF6E00'</default>
       <summary>Default graph CPU color</summary>

--- a/src/preferences.ui
+++ b/src/preferences.ui
@@ -12,6 +12,13 @@
     <property name="can-focus">False</property>
     <property name="icon-name">help-browser</property>
   </object>
+  <object class="GtkAdjustment" id="num_cpu_columns_adjustment">
+    <property name="lower">3</property>
+    <property name="upper">12</property>
+    <property name="value">4</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">4</property>
+  </object>
   <object class="GtkDialog" id="preferences_dialog">
     <property name="can-focus">False</property>
     <property name="border-width">5</property>
@@ -359,16 +366,18 @@
                             <property name="vexpand">True</property>
                             <property name="row-spacing">6</property>
                             <child>
-                              <!-- n-columns=2 n-rows=1 -->
+                              <!-- n-columns=2 n-rows=2 -->
                               <object class="GtkGrid" id="resources_update_interval">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="hexpand">True</property>
+                                <property name="row-spacing">6</property>
                                 <property name="column-spacing">12</property>
                                 <child>
                                   <object class="GtkLabel" id="resources_interval_label">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
                                     <property name="label" translatable="yes">_Update interval in seconds:</property>
                                     <property name="use-underline">True</property>
                                     <property name="mnemonic-widget">resources_interval_spinner</property>
@@ -391,6 +400,32 @@
                                     <property name="top-attach">0</property>
                                   </packing>
                                 </child>
+                                <child>
+                                  <object class="GtkLabel" id="num_cpu_columns_label">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">_Number of CPU columns:</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="mnemonic-widget">num_cpu_columns_spinner</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkSpinButton" id="num_cpu_columns_spinner">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="adjustment">num_cpu_columns_adjustment</property>
+                                    <property name="numeric">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
                                 <property name="left-attach">0</property>
@@ -404,6 +439,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
+                                <property name="halign">start</property>
                                 <property name="hexpand">True</property>
                                 <property name="use-underline">True</property>
                                 <property name="draw-indicator">True</property>

--- a/src/procman.h
+++ b/src/procman.h
@@ -86,6 +86,7 @@ struct ProcConfig
     int         disks_update_interval;
     gint        whose_process;
     gint        current_tab;
+    gint        num_cpu_columns;
     GdkRGBA     cpu_color[GLIBTOP_NCPU];
     GdkRGBA     mem_color;
     GdkRGBA     swap_color;


### PR DESCRIPTION
By default the number of columns is 4, the minimum is 3 and the maximum is 12.

Test:
```
gsettings set org.mate.system-monitor num-cpu-columns 5
```
![Screenshot at 2021-12-15 21-19-54](https://user-images.githubusercontent.com/10171411/146260406-b42121a4-f5cc-4bbc-b3d3-f594597f1c3c.png)

closes #232