### PR TITLE
Fix conversion warnings

### DIFF
--- a/src/gsm_color_button.c
+++ b/src/gsm_color_button.c
@@ -505,9 +505,9 @@ gsm_color_button_drag_data_received (GtkWidget * widget,
 
     dropped = (guint16 *) gtk_selection_data_get_data (selection_data);
 
-    priv->color.red = dropped[0];
-    priv->color.green = dropped[1];
-    priv->color.blue = dropped[2];
+    priv->color.red =   ((double) dropped[0]) / 65535.0;
+    priv->color.green = ((double) dropped[1]) / 65535.0;
+    priv->color.blue =  ((double) dropped[2]) / 65535.0;
 
     gtk_widget_queue_draw (GTK_WIDGET(color_button));
 
@@ -560,9 +560,9 @@ gsm_color_button_drag_data_get (GtkWidget * widget,
 
     priv = gsm_color_button_get_instance_private (color_button);
 
-    dropped[0] = priv->color.red;
-    dropped[1] = priv->color.green;
-    dropped[2] = priv->color.blue;
+    dropped[0] = (guint16) (65535.0 * priv->color.red);
+    dropped[1] = (guint16) (65535.0 * priv->color.green);
+    dropped[2] = (guint16) (65535.0 * priv->color.blue);
     dropped[3] = 65535;        // This widget doesn't care about alpha
 
     gtk_selection_data_set (selection_data, gtk_selection_data_get_target (selection_data),

--- a/tools/msm_execute_helper.c
+++ b/tools/msm_execute_helper.c
@@ -5,8 +5,8 @@
 
 int main(int argc, char* argv[])
 {
-    gchar **argv_modified = g_new0 (gchar *, argc + 1);
-    memcpy (argv_modified, argv, argc * sizeof (char*));
+    gchar **argv_modified = g_new0 (gchar *, (size_t)(argc + 1));
+    memcpy (argv_modified, argv, (size_t)(argc) * sizeof (char*));
     argv_modified[0] = COMMAND;
     int errsv = 0;
 


### PR DESCRIPTION
### Test

[test.webm](https://user-images.githubusercontent.com/10171411/183305860-784ab3f3-87f2-469b-9502-35bd4cfa8794.webm)

```
msm_execute_helper.c:8:51: warning: implicit conversion changes signedness: 'int' to 'gsize' (aka 'unsigned long') [-Wsign-conversion]
    gchar **argv_modified = g_new0 (gchar *, argc + 1);
                            ~~~~~~~~~~~~~~~~~~~~~~^~~~
--
msm_execute_helper.c:9:34: warning: implicit conversion changes signedness: 'int' to 'unsigned long' [-Wsign-conversion]
    memcpy (argv_modified, argv, argc * sizeof (char*));
                                 ^~~~ ~
```
```
gsm_color_button.c:563:30: warning: implicit conversion turns floating-point number into integer: 'gdouble' (aka 'double') to 'guint16' (aka 'unsigned short') [-Wfloat-conversion]
    dropped[0] = priv->color.red;
               ~ ~~~~~~~~~~~~^~~
gsm_color_button.c:564:30: warning: implicit conversion turns floating-point number into integer: 'gdouble' (aka 'double') to 'guint16' (aka 'unsigned short') [-Wfloat-conversion]
    dropped[1] = priv->color.green;
               ~ ~~~~~~~~~~~~^~~~~
gsm_color_button.c:565:30: warning: implicit conversion turns floating-point number into integer: 'gdouble' (aka 'double') to 'guint16' (aka 'unsigned short') [-Wfloat-conversion]
    dropped[2] = priv->color.blue;
               ~ ~~~~~~~~~~~~^~~~
```