### PR TITLE
Fix meson configuration failure on URL keyword 

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,6 @@ project('mate-system-monitor',
     'c_std=c11', 'cpp_std=c++11', 'warning_level=3'
   ],
   version: '1.27.0',
-  url: 'https://mate-desktop.org',
   meson_version: '>=0.50.0',
 )
 


### PR DESCRIPTION
With  mate-system-monitor 1.27.0 and meson version 0.63.3 we get
` meson.build:1:0: ERROR: project got unknown keyword arguments "url"`
 Remove the offending URL line from meson.build to fix this