### PR TITLE
Add GSettings for LoadGraph UI colors

### DIFF
--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -398,6 +398,14 @@ create_sys_view (ProcData *procdata, GtkBuilder * builder)
 
     procdata->net_graph = net_graph;
     g_free(title_template);
+
+    procdata->cpu_graph->background_color = procdata->config.load_graph_background_color;
+    procdata->mem_graph->background_color = procdata->config.load_graph_background_color;
+    procdata->net_graph->background_color = procdata->config.load_graph_background_color;
+
+    procdata->cpu_graph->grid_color = procdata->config.load_graph_grid_color;
+    procdata->mem_graph->grid_color = procdata->config.load_graph_grid_color;
+    procdata->net_graph->grid_color = procdata->config.load_graph_grid_color;
 }
 
 static void
@@ -679,3 +687,4 @@ cb_proc_goto_tab (gint tab)
     ProcData *data = ProcData::get_instance ();
     gtk_notebook_set_current_page (GTK_NOTEBOOK (data->notebook), tab);
 }
+

--- a/src/load-graph.cpp
+++ b/src/load-graph.cpp
@@ -113,7 +113,7 @@ static void draw_background(LoadGraph *graph) {
     cairo_translate (cr, FRAME_WIDTH, FRAME_WIDTH);
 
     /* Draw background rectangle */
-    cairo_set_source_rgb (cr, 1.0, 1.0, 1.0);
+    gdk_cairo_set_source_rgba (cr, &graph->background_color);
     cairo_rectangle (cr, graph->rmargin + graph->indent, 0,
                      graph->draw_width - graph->rmargin - graph->indent, graph->real_draw_height);
     cairo_fill(cr);
@@ -151,9 +151,9 @@ static void draw_background(LoadGraph *graph) {
         }
 
         if (i==0 || i==num_bars)
-          cairo_set_source_rgba (cr, 0.70, 0.71, 0.70, 1.0);
+            gdk_cairo_set_source_rgba (cr, &graph->grid_color);
         else
-          cairo_set_source_rgba (cr, 0.89, 0.89, 0.89, 1.0);
+            gdk_cairo_set_source_rgba (cr, &graph->grid_color);
         cairo_move_to (cr, graph->rmargin + graph->indent - 3, i * graph->graph_dely + 0.5);
         cairo_line_to (cr, graph->draw_width - 0.5, i * graph->graph_dely + 0.5);
         cairo_stroke (cr);
@@ -164,9 +164,9 @@ static void draw_background(LoadGraph *graph) {
     for (unsigned int i = 0; i < 7; i++) {
         double x = (i) * (graph->draw_width - graph->rmargin - graph->indent) / 6;
         if (i==0 || i==6)
-          cairo_set_source_rgba (cr, 0.70, 0.71, 0.70, 1.0);
+            gdk_cairo_set_source_rgba (cr, &graph->grid_color);
         else
-          cairo_set_source_rgba (cr, 0.89, 0.89, 0.89, 1.0);
+            gdk_cairo_set_source_rgba (cr, &graph->grid_color);
         cairo_move_to (cr, (ceil(x) + 0.5) + graph->rmargin + graph->indent, 0.5);
         cairo_line_to (cr, (ceil(x) + 0.5) + graph->rmargin + graph->indent, graph->real_draw_height + 4.5);
         cairo_stroke(cr);
@@ -849,3 +849,4 @@ load_graph_get_swap_color_picker(LoadGraph *graph)
 {
     return graph->swap_color_picker;
 }
+

--- a/src/load-graph.h
+++ b/src/load-graph.h
@@ -55,6 +55,8 @@ struct LoadGraph {
     guint graph_buffer_offset;
 
     std::vector<GdkRGBA> colors;
+    GdkRGBA background_color;
+    GdkRGBA grid_color;
 
     std::vector<float> data_block;
     gfloat* data[NUM_POINTS];
@@ -124,3 +126,4 @@ GtkWidget*
 load_graph_get_swap_color_picker(LoadGraph *g) G_GNUC_CONST;
 
 #endif /* _PROCMAN_LOAD_GRAPH_H_ */
+

--- a/src/org.mate.system-monitor.gschema.xml.in
+++ b/src/org.mate.system-monitor.gschema.xml.in
@@ -201,6 +201,14 @@
       </default>
       <summary>Show network traffic in bits</summary>
     </key>
+    <key name="load-graph-background-color" type="s">
+      <default>'#FFFFFF'</default>
+      <summary>Default graph background color</summary>
+    </key>
+    <key name="load-graph-grid-color" type="s">
+      <default>'#E3E3E3'</default>
+      <summary>Default graph grid color</summary>
+    </key>
     <child name="proctree" schema="org.mate.system-monitor.proctree"/>
     <child name="disktreenew" schema="org.mate.system-monitor.disktreenew"/>
     <child name="memmapstree" schema="org.mate.system-monitor.memmapstree"/>
@@ -537,3 +545,4 @@
     </key>
   </schema>
 </schemalist>
+

--- a/src/procman-app.cpp
+++ b/src/procman-app.cpp
@@ -184,6 +184,18 @@ color_changed_cb (GSettings *settings, const gchar *key, gpointer data)
         gdk_rgba_parse (&procdata->config.net_out_color, color);
         procdata->net_graph->colors.at(1) = procdata->config.net_out_color;
     }
+    else if (g_str_equal (key, "load-graph-background-color")) {
+        gdk_rgba_parse (&procdata->config.load_graph_background_color, color);
+        procdata->cpu_graph->background_color = procdata->config.load_graph_background_color;
+        procdata->mem_graph->background_color = procdata->config.load_graph_background_color;
+        procdata->net_graph->background_color = procdata->config.load_graph_background_color;
+    }
+    else if (g_str_equal (key, "load-graph-grid-color")) {
+        gdk_rgba_parse (&procdata->config.load_graph_grid_color, color);
+        procdata->cpu_graph->grid_color = procdata->config.load_graph_grid_color;
+        procdata->mem_graph->grid_color = procdata->config.load_graph_grid_color;
+        procdata->net_graph->grid_color = procdata->config.load_graph_grid_color;
+    }
     else {
         g_assert_not_reached();
     }
@@ -304,6 +316,22 @@ procman_data_new (GSettings *settings)
     g_signal_connect (G_OBJECT(settings), "changed::net-out-color",
                       G_CALLBACK(color_changed_cb), pd);
     gdk_rgba_parse(&pd->config.net_out_color, color);
+    g_free (color);
+
+    color = g_settings_get_string (settings, "load-graph-background-color");
+    if (!color)
+        color = g_strdup ("#ffffff");
+    g_signal_connect (G_OBJECT(settings), "changed::load-graph-background-color",
+                      G_CALLBACK(color_changed_cb), pd);
+    gdk_rgba_parse(&pd->config.load_graph_background_color, color);
+    g_free (color);
+
+    color = g_settings_get_string (settings, "load-graph-grid-color");
+    if (!color)
+        color = g_strdup ("#e3e3e3");
+    g_signal_connect (G_OBJECT(settings), "changed::load-graph-grid-color",
+                      G_CALLBACK(color_changed_cb), pd);
+    gdk_rgba_parse(&pd->config.load_graph_grid_color, color);
     g_free (color);
 
     /* Sanity checks */
@@ -433,4 +461,5 @@ void ProcmanApp::on_shutdown()
     procman_free_data(procdata);
     glibtop_close();
 }
+
 

--- a/src/procman.h
+++ b/src/procman.h
@@ -93,6 +93,8 @@ struct ProcConfig
     GdkRGBA     net_out_color;
     GdkRGBA     bg_color;
     GdkRGBA     frame_color;
+    GdkRGBA     load_graph_background_color;
+    GdkRGBA     load_graph_grid_color;
     gint        num_cpus;
     bool solaris_mode;
     bool network_in_bits;
@@ -261,3 +263,4 @@ struct KillArgs
 };
 
 #endif /* _PROCMAN_PROCMAN_H_ */
+


### PR DESCRIPTION
Makes the background color and grid color for the load graphs configurable instead of being hardcoded to #FFFFFF and #E3E3E3.

New GSettings keys added to the schema:
* load-graph-background-color    (default: #FFFFFF)
* load-graph-grid-color          (default: #E3E3E3)

Fixes: #88