### PR TITLE
Use transparent background for graph

### DIFF
--- a/src/load-graph.cpp
+++ b/src/load-graph.cpp
@@ -74,7 +74,7 @@ static void draw_background(LoadGraph *graph) {
     PangoFontDescription* font_desc;
     PangoRectangle extents;
     cairo_surface_t *surface;
-    GdkRGBA fg, bg;
+    GdkRGBA fg, bg = { 0.0, 0.0, 0.0, 0.0 };
 
     num_bars = graph->num_bars();
     graph->graph_dely = (graph->draw_height - 15) / num_bars; /* round to int to avoid AA blur */
@@ -89,7 +89,6 @@ static void draw_background(LoadGraph *graph) {
     GtkStyleContext *context = gtk_widget_get_style_context (ProcData::get_instance()->notebook);
     gtk_style_context_save (context);
     gtk_style_context_set_state (context, GTK_STATE_FLAG_NORMAL);
-    gtk_style_context_get_background_color (context, gtk_style_context_get_state (context), &bg);
     gtk_style_context_get_color (context, gtk_style_context_get_state (context), &fg);
     gtk_style_context_restore (context);
 


### PR DESCRIPTION
Fix #265.

To test, open mate-system-monitor:
![1](https://github.com/user-attachments/assets/6d064d11-0883-4aa4-8aa8-d80625234c27)

Then change theme from mate-appearance-properties, wrong background-color:
![2](https://github.com/user-attachments/assets/e555a9b6-907e-43c2-9bbb-8dc806c418da)

With the PR, good background-color:
![3](https://github.com/user-attachments/assets/3e389c22-36b2-486c-9032-c879a9359d3a)
