### PR TITLE
fix crash when sorting process table with NULL string fields

### DIFF
--- a/src/cgroups.cpp
+++ b/src/cgroups.cpp
@@ -143,8 +143,11 @@ get_process_cgroup_info(ProcInfo *info)
     char **lines;
     int i;
 
-    if (!cgroups_enabled())
+    if (!cgroups_enabled()) {
+        if (!info->cgroup_name)
+            info->cgroup_name = g_strdup ("");
         return;
+    }
 
     /* read out of /proc/pid/cgroup */
     path = g_strdup_printf("/proc/%d/cgroup", info->pid);

--- a/src/proctable.cpp
+++ b/src/proctable.cpp
@@ -817,7 +817,7 @@ get_process_systemd_info(ProcInfo *info)
     uid_t uid;
 
     if (!LOGIND_RUNNING())
-        return;
+        goto out;
 
     free(info->unit);
     info->unit = NULL;
@@ -837,7 +837,16 @@ get_process_systemd_info(ProcInfo *info)
         info->owner = info->lookup_user(uid);
     else
         info->owner = "";
+
+out:
 #endif
+
+    if (!info->unit)
+        info->unit = strdup ("");
+    if (!info->session)
+        info->session = strdup ("");
+    if (!info->seat)
+        info->seat = strdup ("");
 }
 
 static void

--- a/src/selinux.cpp
+++ b/src/selinux.cpp
@@ -33,6 +33,9 @@ get_process_selinux_context (ProcInfo *info)
         info->security_context = g_strdup (con);
         freecon (con);
     }
+
+    if (!info->security_context)
+        info->security_context = g_strdup ("");
 }
 
 


### PR DESCRIPTION
Several string fields (security context, cgroup name, systemd unit, session, seat) could be NULL when unavailable for a process. GTK tree store sort dereferences these through g_utf8_collate, causing a segfault.

Ensure these fields default to an empty string instead of NULL.

Fixes #270