### PR TITLE
Add optional NVIDIA GPU utilization history and metrics

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,7 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	CFLAGS='-Wno-deprecated-declarations'
 
 EXTRA_DIST = \
+	NVIDIA-MONITORING.md \
 	autogen.sh \
 	$(man_MANS) \
 	$(appdata_in_files) \

--- a/NVIDIA-MONITORING.md
+++ b/NVIDIA-MONITORING.md
@@ -1,0 +1,151 @@
+# Optional NVIDIA monitoring
+
+The Resources page gains a bold **NVIDIA GPU History** section directly below
+CPU History, containing one 60-second utilization graph per physical GPU,
+with name, current utilization percentage, VRAM used/total in MiB, and
+temperature in degrees Celsius. VRAM also has a level bar. Per-process GPU
+accounting is outside this patch.
+The Resources page scrolls so multiple adapters do not make the window grow
+without limit. The GPU UUID is available as the row tooltip.
+
+## Architecture and failure handling
+
+* `src/nvidia-smi.{h,cpp}`: GTK-independent sample model and parser. Each metric
+  can be unavailable independently. Rejects invalid/out-of-range numeric input,
+  tolerates unsupported fields and bad rows, and deduplicates UUIDs. UUIDs keep
+  widget identity stable when enumeration order changes.
+* `src/gpu-monitor.{h,cpp}`: GTK presentation, timestamped bounded history,
+  Cairo graph rendering, and asynchronous GIO controller.
+  Executes one read-only query for all adapters, with an argument vector (no
+  shell), the C locale, and discarded diagnostic stderr. No CUDA/NVML headers,
+  library linkage, driver installation, or elevated privileges are required.
+* `src/interface.cpp`: attaches the controller to the Resources container.
+  `src/interface.ui` makes Resources scrollable for small screens and large CPU
+  counts. Widget destruction removes timers, terminates/cancels pending work, and
+  asynchronous shared ownership keeps callback state alive until completion.
+* `src/meson.build`, `src/Makefile.am`: add the implementation and the tests.
+  `po/POTFILES.in` registers new UI strings. Root `Makefile.am` distributes this
+  document; `README` points to it. `tests/` contains parser and UI/lifecycle tests.
+
+Detection happens only while Resources is mapped. Missing `nvidia-smi`, missing
+hardware, uninitialized/incompatible drivers, permission failures, empty output,
+and query errors all hide the section without dialogs or console errors.
+Failures clear old readings. Valid rows with unsupported metrics display
+“unavailable” rather than claiming zero usage. Removed GPUs are dropped; new
+GPUs and recovery are detected on subsequent queries.
+
+Successful queries are followed by a two-second minimum delay; failures use a
+30-second delay. A one-second timer checks eligibility, so actual timing is
+approximate. Only one asynchronous query is active at a time. A five-second
+watchdog force-exits and cancels a hung query. No synchronous driver operation
+runs in the GTK event loop. Hidden Resources pages do not start new queries;
+an already pending query may finish. Polling can wake a discrete GPU and use
+some CPU, so completely disable it when desired with:
+
+```sh
+MATE_SYSTEM_MONITOR_DISABLE_NVIDIA=1 mate-system-monitor
+```
+
+The backend is deliberately small and optional. NVIDIA warns that `nvidia-smi`
+output is not guaranteed stable across driver releases and recommends NVML for
+long-term compatibility. This implementation uses explicit selective CSV
+columns, validates readings, and fails closed if that interface changes. A
+future dynamically loaded NVML backend could replace collection while retaining
+the per-GPU UI. MIG instance monitoring and AMD/Intel GPUs are outside this patch.
+See [NVIDIA's official nvidia-smi documentation](https://docs.nvidia.com/deploy/nvidia-smi/index.html).
+
+## Build and test (Debian/Ubuntu)
+
+From a checkout containing this feature:
+
+```sh
+sudo apt install build-essential pkg-config meson ninja-build gettext itstool \
+  libgtkmm-3.0-dev libgtop2-dev librsvg2-dev libxml2-dev libsystemd-dev \
+  libpolkit-gobject-1-dev xvfb xauth
+meson setup build -Dsystemd=false
+meson compile -C build
+xvfb-run -a meson test -C build --print-errorlogs
+```
+
+`-Dsystemd=false` is optional and matches the validation configuration. No NVIDIA
+SDK or driver is needed to build or run the tests. Ubuntu may require the
+Universe repository for some build packages. UI tests return skip status 77
+without a display; use `xvfb-run` to actually exercise them.
+
+To run from the checkout without installing, first generate the schema enum:
+
+```sh
+meson compile -C build
+# The enum XML is a generated build target included by the full build.
+glib-compile-schemas build/src
+GSETTINGS_SCHEMA_DIR="$PWD/build/src" ./build/src/mate-system-monitor
+```
+
+Alternatively install with `meson install -C build` using suitable privileges.
+Close other System Monitor instances before testing the new executable. Running
+without installation can produce existing missing-icon warnings because upstream
+loads some icons from the configured installation prefix; install into a local
+prefix for a complete visual test.
+
+The existing Autotools build is also wired up:
+
+```sh
+# Additionally needs autoconf, automake, libtool, autoconf-archive,
+# mate-common and yelp-tools, plus the development packages above.
+./autogen.sh --disable-systemd
+make -j2
+xvfb-run -a make check
+```
+
+Standalone parser test, requiring only a C++11 compiler:
+
+```sh
+c++ -std=c++11 -Wall -Wextra -Werror -Isrc \
+  src/nvidia-smi.cpp tests/nvidia-smi-test.cpp -o /tmp/nvidia-smi-test
+/tmp/nvidia-smi-test
+```
+
+## Tests and manual checks
+
+The parser test covers multiple GPUs, no devices/driver, malformed rows,
+unsupported values, zero utilization, invalid/range/overflow values, duplicate
+identities, CRLF output, and names containing commas.
+
+The UI test supplies a fake executable in a temporary PATH. It checks hidden UI
+before detection, missing executable, two adapters, stable widgets after reorder,
+unsupported metrics, device removal, driver failure, retry backoff, recovery,
+no new polling when hidden, no overlapping queries, the actual five-second
+timeout, destruction during a pending query, and the runtime opt-out.
+
+On NVIDIA hardware, open Resources and compare readings with:
+
+```sh
+nvidia-smi --query-gpu=uuid,utilization.gpu,memory.used,memory.total,temperature.gpu,name --format=csv,noheader,nounits
+```
+
+Also inspect a small window with many adapters, confirm all rows can be reached
+by scrolling, switch away from Resources, and exercise the runtime opt-out.
+Test on the driver versions and hardware that you support; simulated output
+cannot validate individual driver versions or physical sensor accuracy.
+
+## Redraw correction
+
+The Resources scroller exposed existing direct-to-window rendering in the CPU
+color buttons and load graphs. `src/gsm_color_button.c` and `src/load-graph.cpp`
+now draw using GTK's supplied Cairo context, preserving viewport clipping,
+translation, and buffering. Realization schedules drawing rather than painting
+directly. The color-button regression test renders into a supplied image surface
+before and after scrolling: it fails on the old implementation (transparent
+instead of red) and passes on the corrected implementation.
+
+## GPU utilization history
+
+Each UUID owns a separate 60-second history, plotted against monotonic time
+with 0–100% grid lines and a seconds axis. The graph redraws each second while
+Resources is mapped; collection retains the existing two-second minimum delay.
+Samples expire by timestamp and the buffer is additionally capped at 128 points.
+Unavailable readings and sampling gaps longer than five seconds break the line.
+There is no invented zero history at startup, and histories remain associated
+with the same GPU after enumeration reorder. The GPU UI tests cover placement
+between CPU and memory, independent histories, expiry, bounded storage, and
+history retention after device reorder.

--- a/README
+++ b/README
@@ -10,3 +10,5 @@ Optional dependencies :
 - libselinux
 - lsb_release in PATH - recommended on linux
 
+
+Optional NVIDIA GPU monitoring: see NVIDIA-MONITORING.md.

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -8,6 +8,7 @@ src/argv.h
 src/callbacks.cpp
 src/defaulttable.h
 src/disks.cpp
+src/gpu-monitor.cpp
 src/gsm_color_button.c
 src/interface.cpp
 src/interface.ui

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,6 +18,8 @@ mate_system_monitor_cpp_files = \
 	argv.cpp \
 	procman.cpp \
 	interface.cpp \
+	gpu-monitor.cpp \
+	nvidia-smi.cpp \
 	callbacks.cpp \
 	load-graph.cpp \
 	proctable.cpp \
@@ -93,3 +95,16 @@ EXTRA_DIST = \
 MAINTAINERCLEANFILES = $(gsettings_SCHEMAS:.xml=.valid)
 
 -include $(top_srcdir)/git.mk
+
+check_PROGRAMS = nvidia-smi-test
+TESTS = $(check_PROGRAMS)
+nvidia_smi_test_SOURCES = ../tests/nvidia-smi-test.cpp nvidia-smi.cpp nvidia-smi.h
+nvidia_smi_test_CPPFLAGS = -I$(srcdir)
+check_PROGRAMS += gpu-monitor-test
+gpu_monitor_test_SOURCES = ../tests/gpu-monitor-test.cpp nvidia-smi.cpp nvidia-smi.h
+gpu_monitor_test_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)
+gpu_monitor_test_LDADD = @PROCMAN_LIBS@
+check_PROGRAMS += color-button-test
+color_button_test_SOURCES = ../tests/color-button-test.c gsm_color_button.c gsm_color_button.h
+color_button_test_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)
+color_button_test_LDADD = @PROCMAN_LIBS@ -lm

--- a/src/gpu-monitor.cpp
+++ b/src/gpu-monitor.cpp
@@ -1,0 +1,330 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <config.h>
+#include "gpu-monitor.h"
+#include "nvidia-smi.h"
+
+#include <gio/gio.h>
+#include <glib/gi18n.h>
+#include <map>
+#include <memory>
+#include <set>
+#include <deque>
+#include <algorithm>
+
+namespace {
+struct History {
+    std::deque<std::pair<gint64, double>> points;
+
+    void trim(gint64 now)
+    {
+        while (!points.empty() && points.front().first < now - 60 * G_USEC_PER_SEC)
+            points.pop_front();
+    }
+
+    void append(gint64 now, double utilization)
+    {
+        trim(now);
+        points.emplace_back(now, utilization);
+        // Also bound memory if queries complete unusually rapidly.
+        if (points.size() > 128)
+            points.pop_front();
+    }
+};
+
+// Draw into GTK's supplied context so scrolling and partial redraws stay correct.
+gboolean draw_history(GtkWidget *widget, cairo_t *cr, gpointer data)
+{
+    auto& history = *static_cast<History *>(data);
+    const gint64 now = g_get_monotonic_time();
+    history.trim(now);
+    const double left = 56, top = 8;
+    const double width = std::max(1.0, gtk_widget_get_allocated_width(widget) - left - 16);
+    const double height = std::max(1.0, gtk_widget_get_allocated_height(widget) - top - 24);
+    GtkStyleContext *style = gtk_widget_get_style_context(widget);
+    GdkRGBA foreground;
+    gtk_style_context_get_color(style, gtk_style_context_get_state(style), &foreground);
+    gtk_render_background(style, cr, 0, 0,
+                          gtk_widget_get_allocated_width(widget), gtk_widget_get_allocated_height(widget));
+    PangoLayout *layout = gtk_widget_create_pango_layout(widget, nullptr);
+    PangoAttrList *attributes = pango_attr_list_new();
+    pango_attr_list_insert(attributes, pango_attr_scale_new(0.8));
+    pango_layout_set_attributes(layout, attributes);
+    pango_attr_list_unref(attributes);
+    auto text = [&](const char *value, double x, double y, bool right) {
+        pango_layout_set_text(layout, value, -1);
+        int w, h;
+        pango_layout_get_pixel_size(layout, &w, &h);
+        gdk_cairo_set_source_rgba(cr, &foreground);
+        cairo_move_to(cr, right ? x - w : x, y);
+        pango_cairo_show_layout(cr, layout);
+    };
+    cairo_save(cr);
+    cairo_set_line_width(cr, 1);
+    for (int i = 0; i <= 4; ++i) {
+        const double y = top + i * height / 4;
+        cairo_set_source_rgba(cr, foreground.red, foreground.green, foreground.blue, 0.25);
+        cairo_move_to(cr, left, y);
+        cairo_line_to(cr, left + width, y);
+        cairo_stroke(cr);
+        gchar *value = g_strdup_printf("%d%%", 100 - 25 * i);
+        text(value, left - 7, y - 6, true);
+        g_free(value);
+    }
+    for (int i = 0; i <= 6; ++i) {
+        const double x = left + i * width / 6;
+        cairo_set_source_rgba(cr, foreground.red, foreground.green, foreground.blue, 0.25);
+        cairo_move_to(cr, x, top);
+        cairo_line_to(cr, x, top + height);
+        cairo_stroke(cr);
+        gchar *value = i == 0 ? g_strdup_printf(_("%u seconds"), 60u) :
+                               g_strdup_printf("%d", 60 - i * 10);
+        text(value, x, top + height + 3, i == 6);
+        g_free(value);
+    }
+    cairo_rectangle(cr, left, top, width, height);
+    cairo_clip(cr);
+    cairo_set_source_rgb(cr, 0.30, 0.65, 0.12);
+    cairo_set_line_width(cr, 1.5);
+    bool connected = false;
+    gint64 previous = 0;
+    for (const auto& point : history.points) {
+        if (point.second < 0) {
+            connected = false;
+            continue;
+        }
+        const double x = left + width * (1.0 - double(now - point.first) / (60 * G_USEC_PER_SEC));
+        const double y = top + height * (1.0 - point.second / 100);
+        if (connected && point.first - previous <= 5 * G_USEC_PER_SEC)
+            cairo_line_to(cr, x, y);
+        else
+            cairo_move_to(cr, x, y);
+        connected = true;
+        previous = point.first;
+    }
+    cairo_stroke(cr);
+    cairo_restore(cr);
+    g_object_unref(layout);
+    return FALSE;
+}
+
+struct Row {
+    GtkWidget *box;
+    GtkWidget *name;
+    GtkWidget *usage;
+    GtkWidget *graph;
+    History *history;
+    GtkWidget *memory;
+    GtkWidget *temperature;
+};
+
+struct Monitor {
+    GtkWidget *resources = nullptr;
+    GtkWidget *section = nullptr;
+    GtkWidget *rows_box = nullptr;
+    std::map<std::string, Row> rows;
+    GSubprocess *process = nullptr;
+    GCancellable *cancel = nullptr;
+    guint timer = 0;
+    guint deadline = 0;
+    gint64 next_query = 0;
+    bool stopped = false;
+
+    ~Monitor()
+    {
+        g_clear_object(&process);
+        g_clear_object(&cancel);
+    }
+};
+using State = std::shared_ptr<Monitor>;
+
+GtkWidget *label(const char *text)
+{
+    GtkWidget *widget = gtk_label_new(text);
+    gtk_label_set_xalign(GTK_LABEL(widget), 0);
+    gtk_label_set_ellipsize(GTK_LABEL(widget), PANGO_ELLIPSIZE_END);
+    return widget;
+}
+
+Row make_row(Monitor& state)
+{
+    Row row;
+    row.box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 4);
+    row.name = label("");
+    row.usage = label("");
+    row.graph = gtk_drawing_area_new();
+    gtk_widget_set_size_request(row.graph, -1, 110);
+    row.history = new History;
+    g_object_set_data_full(G_OBJECT(row.graph), "gpu-history", row.history,
+                          [](gpointer data) { delete static_cast<History *>(data); });
+    g_signal_connect(row.graph, "draw", G_CALLBACK(draw_history), row.history);
+    row.memory = gtk_progress_bar_new();
+    row.temperature = label("");
+    gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(row.memory), TRUE);
+    for (auto widget : {row.name, row.graph, row.usage, row.memory, row.temperature})
+        gtk_box_pack_start(GTK_BOX(row.box), widget, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(state.rows_box), row.box, FALSE, FALSE, 0);
+    gtk_widget_show_all(row.box);
+    return row;
+}
+
+void update(Monitor& state, const std::vector<Nvidia::Sample>& samples)
+{
+    std::set<std::string> present;
+    for (const auto& sample : samples) {
+        present.insert(sample.uuid);
+        auto found = state.rows.find(sample.uuid);
+        if (found == state.rows.end())
+            found = state.rows.emplace(sample.uuid, make_row(state)).first;
+        Row& row = found->second;
+        gtk_label_set_text(GTK_LABEL(row.name), sample.name.c_str());
+        gtk_widget_set_tooltip_text(row.box, sample.uuid.c_str());
+        gchar *text = sample.utilization < 0 ? g_strdup(_("GPU utilization: unavailable")) :
+            g_strdup_printf(_("GPU utilization: %.0f%%"), sample.utilization);
+        gtk_label_set_text(GTK_LABEL(row.usage), text);
+        row.history->append(g_get_monotonic_time(), sample.utilization);
+        gtk_widget_queue_draw(row.graph);
+        g_free(text);
+        const bool memory_valid = sample.memory_used >= 0 && sample.memory_total > 0;
+        text = memory_valid ? g_strdup_printf(_("VRAM: %.0f / %.0f MiB"),
+                                              sample.memory_used, sample.memory_total) :
+                              g_strdup(_("VRAM: unavailable"));
+        gtk_progress_bar_set_text(GTK_PROGRESS_BAR(row.memory), text);
+        gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(row.memory),
+                                      memory_valid ? sample.memory_used / sample.memory_total : 0);
+        g_free(text);
+        text = sample.temperature < 0 ? g_strdup(_("Temperature: unavailable")) :
+            g_strdup_printf(_("Temperature: %.0f °C"), sample.temperature);
+        gtk_label_set_text(GTK_LABEL(row.temperature), text);
+        g_free(text);
+    }
+    for (auto it = state.rows.begin(); it != state.rows.end();) {
+        if (!present.count(it->first)) {
+            gtk_widget_destroy(it->second.box);
+            it = state.rows.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    gtk_widget_set_visible(state.section, !samples.empty());
+}
+
+gboolean timed_out(gpointer data)
+{
+    auto& state = *static_cast<Monitor *>(data);
+    state.deadline = 0;
+    // Cancellation releases the asynchronous operation even if driver I/O hangs.
+    g_subprocess_force_exit(state.process);
+    g_cancellable_cancel(state.cancel);
+    return G_SOURCE_REMOVE;
+}
+
+void completed(GObject *source, GAsyncResult *result, gpointer data)
+{
+    std::unique_ptr<State> holder(static_cast<State *>(data));
+    Monitor& state = **holder;
+    gchar *output = nullptr;
+    GError *error = nullptr;
+    const bool ok = g_subprocess_communicate_utf8_finish(G_SUBPROCESS(source), result,
+                                                        &output, nullptr, &error);
+    if (state.deadline) {
+        g_source_remove(state.deadline);
+        state.deadline = 0;
+    }
+    if (!state.stopped) {
+        const auto samples = ok && g_subprocess_get_successful(G_SUBPROCESS(source)) ?
+            Nvidia::parse_samples(output ? output : "") : std::vector<Nvidia::Sample>();
+        update(state, samples); // Clear stale metrics on any failure.
+        state.next_query = g_get_monotonic_time() +
+                           (samples.empty() ? 30 : 2) * G_USEC_PER_SEC;
+    }
+    g_free(output);
+    g_clear_error(&error);
+    g_clear_object(&state.process);
+    g_clear_object(&state.cancel);
+}
+
+gboolean poll(gpointer data)
+{
+    State state = *static_cast<State *>(data);
+    if (state->stopped || !gtk_widget_get_mapped(state->resources))
+        return G_SOURCE_CONTINUE;
+    for (const auto& row : state->rows)
+        gtk_widget_queue_draw(row.second.graph);
+    if (state->process || g_get_monotonic_time() < state->next_query)
+        return G_SOURCE_CONTINUE;
+
+    gchar *program = g_find_program_in_path("nvidia-smi");
+    if (!program) {
+        update(*state, {});
+        state->next_query = g_get_monotonic_time() + 30 * G_USEC_PER_SEC;
+        return G_SOURCE_CONTINUE;
+    }
+    GSubprocessLauncher *launcher = g_subprocess_launcher_new(
+        static_cast<GSubprocessFlags>(G_SUBPROCESS_FLAGS_STDOUT_PIPE |
+                                      G_SUBPROCESS_FLAGS_STDERR_SILENCE));
+    g_subprocess_launcher_setenv(launcher, "LC_ALL", "C", TRUE);
+    GError *error = nullptr;
+    state->process = g_subprocess_launcher_spawn(launcher, &error, program,
+        "--query-gpu=uuid,utilization.gpu,memory.used,memory.total,temperature.gpu,name",
+        "--format=csv,noheader,nounits", nullptr);
+    g_free(program);
+    g_object_unref(launcher);
+    if (!state->process) {
+        g_clear_error(&error);
+        update(*state, {});
+        state->next_query = g_get_monotonic_time() + 30 * G_USEC_PER_SEC;
+        return G_SOURCE_CONTINUE;
+    }
+    state->cancel = g_cancellable_new();
+    state->deadline = g_timeout_add_seconds(5, timed_out, state.get());
+    g_subprocess_communicate_utf8_async(state->process, nullptr, state->cancel,
+                                       completed, new State(state));
+    return G_SOURCE_CONTINUE;
+}
+
+void destroyed(GtkWidget *, gpointer data)
+{
+    auto& state = **static_cast<State *>(data);
+    state.stopped = true;
+    if (state.timer) {
+        g_source_remove(state.timer);
+        state.timer = 0;
+    }
+    if (state.deadline) {
+        g_source_remove(state.deadline);
+        state.deadline = 0;
+    }
+    if (state.process) {
+        g_subprocess_force_exit(state.process);
+        g_cancellable_cancel(state.cancel);
+    }
+}
+}
+
+void gpu_monitor_attach(GtkWidget *resources)
+{
+    if (g_strcmp0(g_getenv("MATE_SYSTEM_MONITOR_DISABLE_NVIDIA"), "1") == 0)
+        return;
+    State state = std::make_shared<Monitor>();
+    state->resources = resources;
+    state->section = gtk_box_new(GTK_ORIENTATION_VERTICAL, 10);
+    GtkWidget *heading = label(_("NVIDIA GPU History"));
+    PangoAttrList *attributes = pango_attr_list_new();
+    pango_attr_list_insert(attributes, pango_attr_weight_new(PANGO_WEIGHT_BOLD));
+    gtk_label_set_attributes(GTK_LABEL(heading), attributes);
+    pango_attr_list_unref(attributes);
+    gtk_box_pack_start(GTK_BOX(state->section), heading, FALSE, FALSE, 0);
+    gtk_widget_show(heading);
+    // Parent show_all() must not reveal the section before successful detection.
+    gtk_widget_set_no_show_all(state->section, TRUE);
+    state->rows_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    gtk_box_pack_start(GTK_BOX(state->section), state->rows_box, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(resources), state->section, FALSE, FALSE, 0);
+    gtk_box_reorder_child(GTK_BOX(resources), state->section, 1);
+    gtk_widget_show(state->rows_box);
+    auto holder = new State(state);
+    g_object_set_data_full(G_OBJECT(resources), "nvidia-monitor", holder,
+                          [](gpointer data) { delete static_cast<State *>(data); });
+    g_signal_connect(resources, "destroy", G_CALLBACK(destroyed), holder);
+    state->timer = g_timeout_add_seconds(1, poll, holder);
+}

--- a/src/gpu-monitor.h
+++ b/src/gpu-monitor.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef MSM_GPU_MONITOR_H
+#define MSM_GPU_MONITOR_H
+#include <gtk/gtk.h>
+
+// Lifetime and polling are tied to the Resources container.
+void gpu_monitor_attach(GtkWidget *resources);
+#endif

--- a/src/gsm_color_button.c
+++ b/src/gsm_color_button.c
@@ -222,7 +222,7 @@ fill_image_buffer_from_file (cairo_t *cr, const char *filePath)
 }
 
 static void
-render (GtkWidget * widget)
+render (GtkWidget * widget, cairo_t *cr)
 {
     GSMColorButtonPrivate *priv;
     GSMColorButton *color_button = GSM_COLOR_BUTTON (widget);
@@ -231,7 +231,6 @@ render (GtkWidget * widget)
     GdkRGBA *color;
     GdkRGBA tmp_color = priv->color;
     color = &tmp_color;
-    cairo_t *cr = gdk_cairo_create (gtk_widget_get_window (widget));
     cairo_path_t *path = NULL;
     gint width, height;
     gdouble radius, arc_start, arc_end;
@@ -257,8 +256,8 @@ render (GtkWidget * widget)
     }
     gdk_cairo_set_source_rgba (cr, color);
 
-    width = gdk_window_get_width(gtk_widget_get_window(widget));
-    height = gdk_window_get_height(gtk_widget_get_window(widget));
+    width = gtk_widget_get_allocated_width (widget);
+    height = gtk_widget_get_allocated_height (widget);
 
     switch (priv->type)
         {
@@ -400,13 +399,15 @@ render (GtkWidget * widget)
 
             break;
         }
-    cairo_destroy (cr);
 }
 
 /* Handle exposure events for the color picker's drawing area */
 static gboolean draw (GtkWidget * widget, cairo_t * cr, gpointer data)
 {
-    render (GTK_WIDGET (data));
+    /* GTK owns the context and its viewport clipping/translation. */
+    cairo_save (cr);
+    render (widget, cr);
+    cairo_restore (cr);
 
     return FALSE;
 }
@@ -415,7 +416,7 @@ static void
 gsm_color_button_realize (GtkWidget * widget)
 {
     GTK_WIDGET_CLASS (gsm_color_button_parent_class)->realize (widget);
-    render (widget);
+    gtk_widget_queue_draw (widget);
 }
 
 static void gsm_color_button_get_preferred_width (GtkWidget * widget, gint * minimum_width, gint * natural_width)

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -41,6 +41,7 @@
 #include "disks.h"
 #include "sysinfo.h"
 #include "gsm_color_button.h"
+#include "gpu-monitor.h"
 
 static void    cb_toggle_tree (GtkAction *action, gpointer data);
 static void    cb_proc_goto_tab (gint tab);
@@ -397,6 +398,7 @@ create_sys_view (ProcData *procdata, GtkBuilder * builder)
     gtk_grid_attach (GTK_GRID (table), label, 6, 1, 1, 1);
 
     procdata->net_graph = net_graph;
+    gpu_monitor_attach(GTK_WIDGET(gtk_builder_get_object(builder, "res_box")));
     g_free(title_template);
 }
 

--- a/src/interface.ui
+++ b/src/interface.ui
@@ -119,6 +119,11 @@
               </packing>
             </child>
             <child>
+              <object class="GtkScrolledWindow" id="res_scrolled">
+                <property name="visible">True</property>
+                <property name="hscrollbar-policy">never</property>
+                <property name="vscrollbar-policy">automatic</property>
+                <child>
               <object class="GtkBox" id="res_box">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -469,6 +474,8 @@
                     <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
+                </child>
+              </object>
                 </child>
               </object>
               <packing>

--- a/src/load-graph.cpp
+++ b/src/load-graph.cpp
@@ -222,12 +222,10 @@ load_graph_configure (GtkWidget *widget,
 static gboolean load_graph_draw (GtkWidget *widget, cairo_t *context, gpointer data_ptr)
 {
     LoadGraph * const graph = static_cast<LoadGraph*>(data_ptr);
-    GdkWindow *window;
 
     guint i, j;
     gdouble sample_width, x_offset;
 
-    window = gtk_widget_get_window (graph->disp);
 
     /* Number of pixels wide for one graph point */
     sample_width = (float)(graph->draw_width - graph->rmargin - graph->indent) / (float)LoadGraph::NUM_POINTS;
@@ -238,9 +236,9 @@ static gboolean load_graph_draw (GtkWidget *widget, cairo_t *context, gpointer d
     x_offset += graph->rmargin - ((sample_width / graph->frames_per_unit) * graph->render_counter);
 
     /* draw the graph */
-    cairo_t* cr;
-
-    cr = gdk_cairo_create (window);
+    // Preserve GTK's context, including viewport clipping and translation.
+    cairo_t* cr = context;
+    cairo_save (cr);
 
     if (graph->background == NULL) {
         draw_background(graph);
@@ -274,7 +272,7 @@ static gboolean load_graph_draw (GtkWidget *widget, cairo_t *context, gpointer d
 
     }
 
-    cairo_destroy (cr);
+    cairo_restore (cr);
 
     return TRUE;
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,6 +10,8 @@ system_monitor_sources += [
   'argv.cpp',
   'procman.cpp',
   'interface.cpp',
+  'gpu-monitor.cpp',
+  'nvidia-smi.cpp',
   'callbacks.cpp',
   'load-graph.cpp',
   'proctable.cpp',
@@ -45,6 +47,8 @@ system_monitor_headers = [
   'gsm_color_button.h',
   'iconthemewrapper.h',
   'interface.h',
+  'gpu-monitor.h',
+  'nvidia-smi.h',
   'load-graph.h',
   'lsof.h',
   'memmaps.h',
@@ -101,3 +105,24 @@ executable(meson.project_name(),
   install: true,
   install_dir : get_option('bindir')
 )
+
+nvidia_parser_test = executable('nvidia-smi-test',
+  '../tests/nvidia-smi-test.cpp', 'nvidia-smi.cpp',
+  include_directories: include_directories('.'),
+)
+test('nvidia-smi-parser', nvidia_parser_test)
+
+nvidia_ui_test = executable('gpu-monitor-test',
+  '../tests/gpu-monitor-test.cpp', 'nvidia-smi.cpp',
+  include_directories: [rootInclude, include_directories('.')],
+  dependencies: [gtk3, dependency('gio-2.0')],
+)
+test('nvidia-gpu-ui', nvidia_ui_test, timeout: 30)
+
+color_button_test = executable('color-button-test',
+  '../tests/color-button-test.c', 'gsm_color_button.c',
+  include_directories: [rootInclude, include_directories('.')],
+  dependencies: [gtk3, librsvg],
+  link_args: ['-lm'],
+)
+test('color-button-redraw', color_button_test)

--- a/src/nvidia-smi.cpp
+++ b/src/nvidia-smi.cpp
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include "nvidia-smi.h"
+
+#include <cmath>
+#include <locale>
+#include <set>
+#include <sstream>
+
+namespace {
+std::string trim(const std::string& value)
+{
+    const auto first = value.find_first_not_of(" \t\r");
+    if (first == std::string::npos)
+        return {};
+    return value.substr(first, value.find_last_not_of(" \t\r") - first + 1);
+}
+
+double number(const std::string& text, double maximum)
+{
+    std::istringstream input(text);
+    input.imbue(std::locale::classic());
+    double result;
+    if (!(input >> result) || !std::isfinite(result) || result < 0 || result > maximum)
+        return -1;
+    input >> std::ws;
+    return input.eof() ? result : -1;
+}
+}
+
+std::vector<Nvidia::Sample> Nvidia::parse_samples(const std::string& output)
+{
+    std::vector<Sample> samples;
+    std::set<std::string> seen;
+    std::istringstream lines(output);
+    std::string line;
+    while (std::getline(lines, line)) {
+        std::string fields[6];
+        size_t start = 0;
+        bool valid = true;
+        for (unsigned i = 0; i < 5; ++i) {
+            const auto comma = line.find(',', start);
+            if (comma == std::string::npos) {
+                valid = false;
+                break;
+            }
+            fields[i] = trim(line.substr(start, comma - start));
+            start = comma + 1;
+        }
+        if (!valid)
+            continue;
+        fields[5] = trim(line.substr(start)); // Device names may contain commas.
+        if (fields[0].compare(0, 4, "GPU-") != 0 || fields[0].size() <= 4 ||
+            !seen.insert(fields[0]).second)
+            continue;
+        Sample sample;
+        sample.uuid = fields[0];
+        sample.name = fields[5].empty() ? sample.uuid : fields[5];
+        sample.utilization = number(fields[1], 100);
+        sample.memory_used = number(fields[2], 1e12);
+        sample.memory_total = number(fields[3], 1e12);
+        sample.temperature = number(fields[4], 1000);
+        if (sample.memory_total == 0 ||
+            (sample.memory_total >= 0 && sample.memory_used > sample.memory_total)) {
+            sample.memory_used = sample.memory_total = -1;
+        }
+        samples.push_back(sample);
+    }
+    return samples;
+}

--- a/src/nvidia-smi.h
+++ b/src/nvidia-smi.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef MSM_NVIDIA_SMI_H
+#define MSM_NVIDIA_SMI_H
+
+#include <string>
+#include <vector>
+
+namespace Nvidia {
+struct Sample {
+    std::string uuid;
+    std::string name;
+    // Negative values mean unavailable, never zero usage.
+    double utilization = -1;
+    double memory_used = -1;  // MiB, as returned by nvidia-smi
+    double memory_total = -1;
+    double temperature = -1;  // Celsius
+};
+
+// Columns: uuid, utilization.gpu, memory.used, memory.total, temperature.gpu, name.
+std::vector<Sample> parse_samples(const std::string& output);
+}
+#endif

--- a/tests/color-button-test.c
+++ b/tests/color-button-test.c
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <gtk/gtk.h>
+#include <stdint.h>
+#include "gsm_color_button.h"
+
+static void assert_color(GtkWidget *button)
+{
+    int width = gtk_widget_get_allocated_width(button);
+    int height = gtk_widget_get_allocated_height(button);
+    cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+    cairo_t *cr = cairo_create(surface);
+    gtk_widget_draw(button, cr);
+    cairo_surface_flush(surface);
+    unsigned char *data = cairo_image_surface_get_data(surface);
+    int stride = cairo_image_surface_get_stride(surface);
+    uint32_t pixel = *(uint32_t *)(data + (height / 2) * stride + (width / 2) * 4);
+    // The CPU swatch must paint into GTK's supplied surface, not its GdkWindow.
+    g_assert_cmphex(pixel, ==, 0xffff0000);
+    cairo_destroy(cr);
+    cairo_surface_destroy(surface);
+}
+
+int main(int argc, char **argv)
+{
+    if (!gtk_init_check(&argc, &argv))
+        return 77;
+    GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    GtkWidget *scroll = gtk_scrolled_window_new(NULL, NULL);
+    GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    GdkRGBA red = {1, 0, 0, 1};
+    GtkWidget *button = gsm_color_button_new(&red, GSMCP_TYPE_CPU);
+    GtkWidget *spacer = gtk_drawing_area_new();
+    gtk_widget_set_size_request(spacer, 100, 1000);
+    gtk_container_add(GTK_CONTAINER(window), scroll);
+    gtk_container_add(GTK_CONTAINER(scroll), box);
+    gtk_box_pack_start(GTK_BOX(box), button, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(box), spacer, FALSE, FALSE, 0);
+    gtk_window_set_default_size(GTK_WINDOW(window), 200, 200);
+    gtk_widget_show_all(window);
+    while (g_main_context_iteration(NULL, FALSE)) {}
+    assert_color(button);
+    GtkAdjustment *adjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(scroll));
+    gtk_adjustment_set_value(adjustment, 500);
+    while (g_main_context_iteration(NULL, FALSE)) {}
+    gtk_adjustment_set_value(adjustment, 0);
+    gtk_widget_queue_draw(button);
+    while (g_main_context_iteration(NULL, FALSE)) {}
+    assert_color(button);
+    gtk_widget_destroy(window);
+    g_print("Color button redraw test passed\n");
+    return 0;
+}

--- a/tests/gpu-monitor-test.cpp
+++ b/tests/gpu-monitor-test.cpp
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+// Include the controller to exercise its private lifecycle with a fake executable.
+#include "gpu-monitor.cpp"
+#include <glib/gstdio.h>
+
+static void drain(const State& state)
+{
+    const gint64 limit = g_get_monotonic_time() + 8 * G_USEC_PER_SEC;
+    while (state->process && g_get_monotonic_time() < limit) {
+        while (g_main_context_iteration(nullptr, FALSE)) {}
+        g_usleep(1000);
+    }
+    g_assert_null(state->process);
+}
+
+int main(int argc, char **argv)
+{
+    g_setenv("LC_ALL", "C", TRUE);
+    g_setenv("LANGUAGE", "C", TRUE);
+    if (!gtk_init_check(&argc, &argv))
+        return 77; // Use xvfb-run on headless builders.
+    History history;
+    history.append(0, 10);
+    history.append(30 * G_USEC_PER_SEC, -1);
+    history.append(61 * G_USEC_PER_SEC, 90);
+    g_assert_cmpuint(history.points.size(), ==, 2);
+    g_assert_cmpfloat(history.points.front().second, ==, -1);
+    for (int i = 0; i < 200; ++i)
+        history.append(61 * G_USEC_PER_SEC + i, 50);
+    g_assert_cmpuint(history.points.size(), ==, 128);
+    g_unsetenv("MATE_SYSTEM_MONITOR_DISABLE_NVIDIA");
+    gchar *dir = g_dir_make_tmp("msm-gpu-test-XXXXXX", nullptr);
+    g_assert_nonnull(dir);
+    gchar *program = g_build_filename(dir, "nvidia-smi", nullptr);
+    g_setenv("PATH", dir, TRUE);
+    auto script = [&](const char *body) {
+        g_assert_true(g_file_set_contents(program, body, -1, nullptr));
+        g_assert_cmpint(g_chmod(program, 0700), ==, 0);
+    };
+    GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    GtkWidget *resources = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_container_add(GTK_CONTAINER(window), resources);
+    GtkWidget *cpu = gtk_label_new("CPU History");
+    GtkWidget *memory = gtk_label_new("Memory and Swap History");
+    gtk_box_pack_start(GTK_BOX(resources), cpu, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(resources), memory, FALSE, FALSE, 0);
+    gpu_monitor_attach(resources);
+    gtk_widget_show_all(window);
+    State state = *static_cast<State *>(g_object_get_data(G_OBJECT(resources), "nvidia-monitor"));
+    GList *children = gtk_container_get_children(GTK_CONTAINER(resources));
+    g_assert_true(g_list_nth_data(children, 0) == cpu);
+    g_assert_true(g_list_nth_data(children, 1) == state->section);
+    g_assert_true(g_list_nth_data(children, 2) == memory);
+    g_list_free(children);
+    g_source_remove(state->timer);
+    state->timer = 0; // Tests drive polls deterministically.
+    auto query = [&]() { state->next_query = 0; poll(&state); drain(state); };
+    g_assert_false(gtk_widget_get_visible(state->section));
+    query(); // No executable.
+    g_assert_true(state->rows.empty());
+    script("#!/bin/sh\nprintf 'GPU-a, 37, 4096, 8192, 61, First\\nGPU-b, N/A, 0, 4096, N/A, Second\\n'\n");
+    query();
+    g_assert_cmpuint(state->rows.size(), ==, 2);
+    g_assert_true(gtk_widget_get_visible(state->section));
+    GtkWidget *first = state->rows.at("GPU-a").box;
+    g_assert_cmpuint(state->rows.at("GPU-a").history->points.size(), ==, 1);
+    g_assert_cmpfloat(state->rows.at("GPU-a").history->points.back().second, ==, 37);
+    g_assert_cmpfloat(state->rows.at("GPU-b").history->points.back().second, ==, -1);
+    g_assert_cmpfloat(gtk_progress_bar_get_fraction(GTK_PROGRESS_BAR(state->rows.at("GPU-a").memory)), ==, 0.5);
+    g_assert_cmpstr(gtk_label_get_text(GTK_LABEL(state->rows.at("GPU-b").usage)), ==, "GPU utilization: unavailable");
+    script("#!/bin/sh\nprintf 'GPU-b, 1, 0, 4096, 40, Second\\nGPU-a, 2, 1, 8192, 50, First\\n'\n");
+    query();
+    g_assert_cmpuint(state->rows.at("GPU-a").history->points.size(), ==, 2);
+    g_assert_true(first == state->rows.at("GPU-a").box); // Stable identity after reorder.
+    gtk_widget_hide(resources);
+    state->next_query = 0;
+    poll(&state);
+    g_assert_null(state->process);
+    gtk_widget_show(resources);
+    script("#!/bin/sh\nprintf 'GPU-a, 2, 1, 8192, 50, First\\n'\n");
+    query();
+    g_assert_cmpuint(state->rows.size(), ==, 1); // Device removal.
+    script("#!/bin/sh\necho driver-failure >&2\nexit 9\n");
+    query();
+    g_assert_true(state->rows.empty());
+    g_assert_false(gtk_widget_get_visible(state->section));
+    g_assert_cmpint(state->next_query - g_get_monotonic_time(), >, 25 * G_USEC_PER_SEC);
+    script("#!/bin/sh\nprintf 'GPU-a, 0, 0, 8192, 45, Recovered\\n'\n");
+    query();
+    g_assert_cmpuint(state->rows.size(), ==, 1);
+    script("#!/bin/sh\nexec /bin/sleep 30\n");
+    state->next_query = 0;
+    poll(&state);
+    GSubprocess *pending = state->process;
+    poll(&state);
+    g_assert_true(pending == state->process); // No overlapping queries.
+    drain(state); // Actual five-second timeout and cancellation.
+    g_assert_true(state->rows.empty());
+    state->next_query = 0;
+    poll(&state);
+    gtk_widget_destroy(window); // Destroy during an asynchronous query.
+    drain(state);
+    g_assert_true(state->stopped);
+    g_assert_cmpuint(state->deadline, ==, 0);
+    g_setenv("MATE_SYSTEM_MONITOR_DISABLE_NVIDIA", "1", TRUE);
+    resources = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    g_object_ref_sink(resources);
+    gpu_monitor_attach(resources);
+    g_assert_null(g_object_get_data(G_OBJECT(resources), "nvidia-monitor"));
+    gtk_widget_destroy(resources);
+    g_object_unref(resources);
+    g_remove(program);
+    g_rmdir(dir);
+    g_free(program);
+    g_free(dir);
+    g_print("NVIDIA UI/lifecycle tests passed\n");
+}

--- a/tests/nvidia-smi-test.cpp
+++ b/tests/nvidia-smi-test.cpp
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include "nvidia-smi.h"
+#include <cstdlib>
+#include <iostream>
+
+#define CHECK(value) do { if (!(value)) { std::cerr << "Failed line " << __LINE__ << '\n'; std::exit(1); } } while (0)
+int main()
+{
+    CHECK(Nvidia::parse_samples("").empty());
+    CHECK(Nvidia::parse_samples("No devices were found\n").empty());
+    CHECK(Nvidia::parse_samples("NVIDIA-SMI has failed\n").empty());
+    CHECK(Nvidia::parse_samples("GPU-a, 10, 20\n").empty());
+    auto samples = Nvidia::parse_samples(
+        "GPU-a, 37, 4096, 8192, 61, NVIDIA First\r\n"
+        "GPU-b, N/A, [Not Supported], 16384, N/A, NVIDIA Second, Special\n");
+    CHECK(samples.size() == 2);
+    CHECK(samples[0].uuid == "GPU-a" && samples[1].uuid == "GPU-b");
+    CHECK(samples[0].utilization == 37 && samples[0].memory_used == 4096);
+    CHECK(samples[0].memory_total == 8192 && samples[0].temperature == 61);
+    CHECK(samples[1].utilization == -1 && samples[1].temperature == -1);
+    CHECK(samples[1].memory_used == -1 && samples[1].memory_total == 16384);
+    CHECK(samples[1].name == "NVIDIA Second, Special");
+    samples = Nvidia::parse_samples("GPU-a, 0, 0, 8192, 0, Idle\nGPU-a, 99, 1, 2, 3, Duplicate\n");
+    CHECK(samples.size() == 1 && samples[0].utilization == 0 && samples[0].memory_used == 0);
+    for (auto bad : {"-1", "nan", "inf", "101", "1%", "", "1e9999"}) {
+        samples = Nvidia::parse_samples(std::string("GPU-a, ") + bad + ", 9, 8, -1, Bad\n");
+        CHECK(samples.size() == 1 && samples[0].utilization == -1);
+        CHECK(samples[0].memory_used == -1 && samples[0].memory_total == -1);
+        CHECK(samples[0].temperature == -1);
+    }
+    samples = Nvidia::parse_samples("GPU-a, 1, 0, 0, 12, Zero\n");
+    CHECK(samples[0].memory_total == -1);
+    std::cout << "NVIDIA parser tests passed\n";
+}


### PR DESCRIPTION
Adds an optional **NVIDIA GPU History** section below CPU History in Resources, with a separate 60-second utilization graph, current utilization, VRAM used/total, and temperature for each GPU. The application name remains unchanged.

Collection uses asynchronous, read-only `nvidia-smi` queries through GIO, without NVIDIA headers or library dependencies. Missing hardware, tools, or drivers quietly hide the section; unsupported metrics display “unavailable.” Queries have a five-second timeout, retry backoff, and cancellation on destruction. Polling pauses while Resources is hidden. UUIDs preserve each GPU's history across enumeration reorder, and unavailable samples or long sampling gaps break the graph line.

Resources is scrollable to accommodate multiple adapters and large CPU legends. The existing color buttons and load graphs now use GTK's supplied Cairo drawing context: their direct-to-window painting caused missing colors when placed inside the viewport. A regression test fails with the original color-button code and passes with the correction.

Both Meson and Autotools include the implementation and tests. `NVIDIA-MONITORING.md` documents architecture, collection tradeoffs, the runtime opt-out, and build/test instructions. The selective CSV interface keeps the integration small, but NVIDIA does not guarantee its stability across releases; a dynamically loaded NVML backend could be considered separately.

Validation:
- Full Meson build on Ubuntu 24.04 / GCC 13 / GTK 3.24, with `-Dsystemd=false`.
- All four Meson tests pass under Xvfb with `G_DEBUG=fatal-warnings`, with no skips: desktop validation, parser, GPU UI/lifecycle, and color-button redraw.
- Simulated multi-GPU tests cover unsupported readings, reorder/removal, driver failure and recovery, timeout, shutdown, history retention/expiry, and section ordering.
- Installed application checked on a GeForce RTX 3090, including GPU history and scrolling away from and back to the CPU colors.

Autotools wiring is included but has not been executed; physical multi-GPU and MIG configurations have not been validated. MIG instance monitoring is outside this change.
